### PR TITLE
Fix implicit declaration of function 'Nop'

### DIFF
--- a/PSLab_Original/COMMANDS.h
+++ b/PSLab_Original/COMMANDS.h
@@ -8,6 +8,7 @@
 #ifndef COMMANDS_H
 #define	COMMANDS_H
 
+#include <xc.h>
 #include <p24EP256GP204.h>
 #include <libpic30.h>
 

--- a/PSLab_Original/proto2_main.c
+++ b/PSLab_Original/proto2_main.c
@@ -22,7 +22,6 @@
 // SCL Settings
 #pragma config ALTI2C2  = OFF   // Alternate I2C2 pins (I2C2 mapped - SDA2/SCL2)
 
-#include <xc.h>
 #include <p24EP256GP204.h>
 #include <stdlib.h>
 #include <libpic30.h>


### PR DESCRIPTION
Several files use Nop() without including xc.h. Every file in the project includes COMMANDS.h, so moving the xc.h include there fixes the problem.