### PR TITLE
fix: upgrade source code to match new MPLab v5.45 IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 /PSLab_Original/nbproject/private/
 /PSLab_Original/build/default/
 /PSLab_Original/dist/default/
+/PSLab_Original/.generated_files/*
 /MPLABProject/nbproject/private/
 /MPLABProject/build/default/
 /PSLab_Original/nbproject/Makefile-genesis.properties
+/PSLab_Original/build/
+/PSLab_Original/dist/

--- a/PSLab_Original/COMMANDS.h
+++ b/PSLab_Original/COMMANDS.h
@@ -10,6 +10,7 @@
 
 #include <p24EP256GP204.h>
 #include <libpic30.h>
+#include <xc.h>
 
 #define DELAY_105uS asm volatile ("REPEAT, #6721"); Nop(); // 105uS delay
 

--- a/PSLab_Original/Function.c
+++ b/PSLab_Original/Function.c
@@ -310,34 +310,6 @@ void read_all_from_flash(_prog_addressT pointer) {
 
 }
 
-void load_to_flash(_prog_addressT pointer, BYTE location, unsigned int * blk) {
-    /*Write to locations of 16bytes each (store 8 integers as a string, or 16 BYTES ...)*/
-    char bytes_to_write = 16;
-    _prog_addressT p;
-    //row_p = pointer;
-    /*The storage architecture only allows erasing a whole page(1024) at a time. So we must make
-     a copy of the data in the RAM, change the locations we need to access, and write the whole page back*/
-
-    /*------fetch a copy of the rows into RAM ( &DEST )------*/
-    read_all_from_flash(pointer);
-
-    /*-----------fetch bytes_to_write characters----------*/
-    for (i = 0; i < bytes_to_write / 2; i++) {
-        dest[location * 8 + i] = blk[i];
-    }
-
-    /*------write the copy back into the FLASH MEMORY------*/
-    unsigned int dat1, dat2;
-    _erase_flash(pointer); /* erase a page */
-    for (i = 0; i < _FLASH_ROW * 4; i += 1) /*combine two ints each for each word32 write*/ {
-        dat1 = dest[2 * i];
-        dat2 = dest[2 * i + 1];
-        p = pointer + (4 * i);
-        _write_flash_word32(p, dat1, dat2);
-    }
-
-
-}
 
 void read_flash(_prog_addressT pointer, BYTE location) {
     read_all_from_flash(pointer);

--- a/PSLab_Original/PSLAB_NRF.h
+++ b/PSLab_Original/PSLAB_NRF.h
@@ -7,6 +7,7 @@
 
 #ifndef PSLAB_NRF_H
 #define	PSLAB_NRF_H
+#include <xc.h>
 
 #define CSN_HIGH _LATC4=1;Nop();
 #define CSN_LOW  _LATC4=0;Nop();

--- a/PSLab_Original/PSLAB_UART.c
+++ b/PSLab_Original/PSLAB_UART.c
@@ -47,7 +47,7 @@ void initUART(uint16 BAUD) {
 
     U1MODEbits.URXINV = 0;
 
-    DELAY_105uS
+    DELAY_105uS  
     while (hasChar())getChar(); //clear buffer
 
 }

--- a/PSLab_Original/nbproject/Makefile-default.mk
+++ b/PSLab_Original/nbproject/Makefile-default.mk
@@ -70,6 +70,7 @@ OBJECTFILES=${OBJECTDIR}/proto2_main.o ${OBJECTDIR}/PSLAB_UART.o ${OBJECTDIR}/PS
 SOURCEFILES=proto2_main.c PSLAB_UART.c PSLAB_I2C.c Common_Functions.c PSLAB_NRF.c PSLAB_SPI.c PSLAB_ADC.c Wave_Generator.c Function.c Measurements.c
 
 
+
 CFLAGS=
 ASFLAGS=
 LDLIBSOPTIONS=
@@ -94,146 +95,126 @@ MP_LINKER_FILE_OPTION=,--script=p24EP256GP204.gld
 # ------------------------------------------------------------------------------------
 # Rules for buildStep: compile
 ifeq ($(TYPE_IMAGE), DEBUG_RUN)
-${OBJECTDIR}/proto2_main.o: proto2_main.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/proto2_main.o: proto2_main.c  .generated_files/b20099725a9b3ab7a072d897c1f53246d5980c0b.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/proto2_main.o.d 
 	@${RM} ${OBJECTDIR}/proto2_main.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  proto2_main.c  -o ${OBJECTDIR}/proto2_main.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/proto2_main.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/proto2_main.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  proto2_main.c  -o ${OBJECTDIR}/proto2_main.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/proto2_main.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/PSLAB_UART.o: PSLAB_UART.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/PSLAB_UART.o: PSLAB_UART.c  .generated_files/1d3997731d7d7b3f2c4ef268b070d6eff4d752a2.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/PSLAB_UART.o.d 
 	@${RM} ${OBJECTDIR}/PSLAB_UART.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_UART.c  -o ${OBJECTDIR}/PSLAB_UART.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/PSLAB_UART.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/PSLAB_UART.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_UART.c  -o ${OBJECTDIR}/PSLAB_UART.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/PSLAB_UART.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/PSLAB_I2C.o: PSLAB_I2C.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/PSLAB_I2C.o: PSLAB_I2C.c  .generated_files/e58e040a3b4183c8459853bce0b5ad1422456c4.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/PSLAB_I2C.o.d 
 	@${RM} ${OBJECTDIR}/PSLAB_I2C.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_I2C.c  -o ${OBJECTDIR}/PSLAB_I2C.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/PSLAB_I2C.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/PSLAB_I2C.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_I2C.c  -o ${OBJECTDIR}/PSLAB_I2C.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/PSLAB_I2C.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/Common_Functions.o: Common_Functions.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/Common_Functions.o: Common_Functions.c  .generated_files/6c35f68299e8bc9ba7824b09ae59f78d65dee39a.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/Common_Functions.o.d 
 	@${RM} ${OBJECTDIR}/Common_Functions.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  Common_Functions.c  -o ${OBJECTDIR}/Common_Functions.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/Common_Functions.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/Common_Functions.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  Common_Functions.c  -o ${OBJECTDIR}/Common_Functions.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/Common_Functions.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/PSLAB_NRF.o: PSLAB_NRF.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/PSLAB_NRF.o: PSLAB_NRF.c  .generated_files/b9557f2318eb95aea2ae34594705a59d9ce7786f.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/PSLAB_NRF.o.d 
 	@${RM} ${OBJECTDIR}/PSLAB_NRF.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_NRF.c  -o ${OBJECTDIR}/PSLAB_NRF.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/PSLAB_NRF.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/PSLAB_NRF.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_NRF.c  -o ${OBJECTDIR}/PSLAB_NRF.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/PSLAB_NRF.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/PSLAB_SPI.o: PSLAB_SPI.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/PSLAB_SPI.o: PSLAB_SPI.c  .generated_files/4e02aa0c1814050ed8fab5cfcccfa21a50ea9ef4.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/PSLAB_SPI.o.d 
 	@${RM} ${OBJECTDIR}/PSLAB_SPI.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_SPI.c  -o ${OBJECTDIR}/PSLAB_SPI.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/PSLAB_SPI.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/PSLAB_SPI.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_SPI.c  -o ${OBJECTDIR}/PSLAB_SPI.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/PSLAB_SPI.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/PSLAB_ADC.o: PSLAB_ADC.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/PSLAB_ADC.o: PSLAB_ADC.c  .generated_files/9c446430167ac5908d747ec2ccf92408182c5711.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/PSLAB_ADC.o.d 
 	@${RM} ${OBJECTDIR}/PSLAB_ADC.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_ADC.c  -o ${OBJECTDIR}/PSLAB_ADC.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/PSLAB_ADC.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/PSLAB_ADC.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_ADC.c  -o ${OBJECTDIR}/PSLAB_ADC.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/PSLAB_ADC.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/Wave_Generator.o: Wave_Generator.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/Wave_Generator.o: Wave_Generator.c  .generated_files/727872c877939ddbb65342c0369a4b23587b5e90.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/Wave_Generator.o.d 
 	@${RM} ${OBJECTDIR}/Wave_Generator.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  Wave_Generator.c  -o ${OBJECTDIR}/Wave_Generator.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/Wave_Generator.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/Wave_Generator.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  Wave_Generator.c  -o ${OBJECTDIR}/Wave_Generator.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/Wave_Generator.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/Function.o: Function.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/Function.o: Function.c  .generated_files/4be293ed99d6f4a60d04ed7d0f5f5fcd9f1f3d84.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/Function.o.d 
 	@${RM} ${OBJECTDIR}/Function.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  Function.c  -o ${OBJECTDIR}/Function.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/Function.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/Function.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  Function.c  -o ${OBJECTDIR}/Function.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/Function.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/Measurements.o: Measurements.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/Measurements.o: Measurements.c  .generated_files/bfa1ca8a92b0900965683913968bb514452b7bbe.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/Measurements.o.d 
 	@${RM} ${OBJECTDIR}/Measurements.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  Measurements.c  -o ${OBJECTDIR}/Measurements.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/Measurements.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/Measurements.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  Measurements.c  -o ${OBJECTDIR}/Measurements.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/Measurements.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -mno-eds-warn  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
 else
-${OBJECTDIR}/proto2_main.o: proto2_main.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/proto2_main.o: proto2_main.c  .generated_files/6a8ecea750e02cb8ba7bac5a029ccfcafc3170fb.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/proto2_main.o.d 
 	@${RM} ${OBJECTDIR}/proto2_main.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  proto2_main.c  -o ${OBJECTDIR}/proto2_main.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/proto2_main.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/proto2_main.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  proto2_main.c  -o ${OBJECTDIR}/proto2_main.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/proto2_main.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/PSLAB_UART.o: PSLAB_UART.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/PSLAB_UART.o: PSLAB_UART.c  .generated_files/b001520bf5037f4b41c2264d14f4ab48aaf0fd0e.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/PSLAB_UART.o.d 
 	@${RM} ${OBJECTDIR}/PSLAB_UART.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_UART.c  -o ${OBJECTDIR}/PSLAB_UART.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/PSLAB_UART.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/PSLAB_UART.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_UART.c  -o ${OBJECTDIR}/PSLAB_UART.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/PSLAB_UART.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/PSLAB_I2C.o: PSLAB_I2C.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/PSLAB_I2C.o: PSLAB_I2C.c  .generated_files/5d4e05acfe1639feffa62d5590012f2a7ad7c2d9.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/PSLAB_I2C.o.d 
 	@${RM} ${OBJECTDIR}/PSLAB_I2C.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_I2C.c  -o ${OBJECTDIR}/PSLAB_I2C.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/PSLAB_I2C.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/PSLAB_I2C.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_I2C.c  -o ${OBJECTDIR}/PSLAB_I2C.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/PSLAB_I2C.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/Common_Functions.o: Common_Functions.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/Common_Functions.o: Common_Functions.c  .generated_files/119eb21a88b6031b4527590b0eceb9d2d0a85c6.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/Common_Functions.o.d 
 	@${RM} ${OBJECTDIR}/Common_Functions.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  Common_Functions.c  -o ${OBJECTDIR}/Common_Functions.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/Common_Functions.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/Common_Functions.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  Common_Functions.c  -o ${OBJECTDIR}/Common_Functions.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/Common_Functions.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/PSLAB_NRF.o: PSLAB_NRF.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/PSLAB_NRF.o: PSLAB_NRF.c  .generated_files/d07505e939d831f2171d0256f857bf5fda166101.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/PSLAB_NRF.o.d 
 	@${RM} ${OBJECTDIR}/PSLAB_NRF.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_NRF.c  -o ${OBJECTDIR}/PSLAB_NRF.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/PSLAB_NRF.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/PSLAB_NRF.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_NRF.c  -o ${OBJECTDIR}/PSLAB_NRF.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/PSLAB_NRF.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/PSLAB_SPI.o: PSLAB_SPI.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/PSLAB_SPI.o: PSLAB_SPI.c  .generated_files/80f24146015c29af017551c02a7843192c6a6aa0.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/PSLAB_SPI.o.d 
 	@${RM} ${OBJECTDIR}/PSLAB_SPI.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_SPI.c  -o ${OBJECTDIR}/PSLAB_SPI.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/PSLAB_SPI.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/PSLAB_SPI.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_SPI.c  -o ${OBJECTDIR}/PSLAB_SPI.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/PSLAB_SPI.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/PSLAB_ADC.o: PSLAB_ADC.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/PSLAB_ADC.o: PSLAB_ADC.c  .generated_files/5013b8460164945f89b71f6718a31a913a81f5a4.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/PSLAB_ADC.o.d 
 	@${RM} ${OBJECTDIR}/PSLAB_ADC.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_ADC.c  -o ${OBJECTDIR}/PSLAB_ADC.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/PSLAB_ADC.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/PSLAB_ADC.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  PSLAB_ADC.c  -o ${OBJECTDIR}/PSLAB_ADC.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/PSLAB_ADC.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/Wave_Generator.o: Wave_Generator.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/Wave_Generator.o: Wave_Generator.c  .generated_files/ff046c15f9d075114a0f51af38c7fa2c78bb34a3.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/Wave_Generator.o.d 
 	@${RM} ${OBJECTDIR}/Wave_Generator.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  Wave_Generator.c  -o ${OBJECTDIR}/Wave_Generator.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/Wave_Generator.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/Wave_Generator.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  Wave_Generator.c  -o ${OBJECTDIR}/Wave_Generator.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/Wave_Generator.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/Function.o: Function.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/Function.o: Function.c  .generated_files/677231b9c13ffea101458aae3e9a2eb2892ff873.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/Function.o.d 
 	@${RM} ${OBJECTDIR}/Function.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  Function.c  -o ${OBJECTDIR}/Function.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/Function.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/Function.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  Function.c  -o ${OBJECTDIR}/Function.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/Function.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
-${OBJECTDIR}/Measurements.o: Measurements.c  nbproject/Makefile-${CND_CONF}.mk
+${OBJECTDIR}/Measurements.o: Measurements.c  .generated_files/eb74b9b63bdcc3e5019ffc754933091b34ada8a6.flag .generated_files/f7c0ce93c58705ae075be29667b4f7f8d13d214d.flag
 	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/Measurements.o.d 
 	@${RM} ${OBJECTDIR}/Measurements.o 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  Measurements.c  -o ${OBJECTDIR}/Measurements.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/Measurements.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off  
-	@${FIXDEPS} "${OBJECTDIR}/Measurements.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  Measurements.c  -o ${OBJECTDIR}/Measurements.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MP -MMD -MF "${OBJECTDIR}/Measurements.o.d"      -mno-eds-warn  -g -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -O1 -msmart-io=1 -Wall -msfr-warn=off    -mdfp="${DFP_DIR}/xc16"
 	
 endif
 
@@ -254,13 +235,13 @@ endif
 ifeq ($(TYPE_IMAGE), DEBUG_RUN)
 dist/${CND_CONF}/${IMAGE_TYPE}/PSLab_Original.${IMAGE_TYPE}.${OUTPUT_SUFFIX}: ${OBJECTFILES}  nbproject/Makefile-${CND_CONF}.mk    
 	@${MKDIR} dist/${CND_CONF}/${IMAGE_TYPE} 
-	${MP_CC} $(MP_EXTRA_LD_PRE)  -o dist/${CND_CONF}/${IMAGE_TYPE}/PSLab_Original.${IMAGE_TYPE}.${OUTPUT_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}      -mcpu=$(MP_PROCESSOR_OPTION)        -D__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)   -mreserve=data@0x1000:0x101B -mreserve=data@0x101C:0x101D -mreserve=data@0x101E:0x101F -mreserve=data@0x1020:0x1021 -mreserve=data@0x1022:0x1023 -mreserve=data@0x1024:0x1027 -mreserve=data@0x1028:0x104F   -Wl,--local-stack,,--defsym=__MPLAB_BUILD=1,--defsym=__MPLAB_DEBUG=1,--defsym=__DEBUG=1,--defsym=__MPLAB_DEBUGGER_PK3=1,$(MP_LINKER_FILE_OPTION),--stack=16,--check-sections,--data-init,--pack-data,--handles,--isr,--no-gc-sections,--fill-upper=0,--stackguard=16,--no-force-link,--smart-io,-Map="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map",--report-mem,--memorysummary,dist/${CND_CONF}/${IMAGE_TYPE}/memoryfile.xml$(MP_EXTRA_LD_POST) 
+	${MP_CC} $(MP_EXTRA_LD_PRE)  -o dist/${CND_CONF}/${IMAGE_TYPE}/PSLab_Original.${IMAGE_TYPE}.${OUTPUT_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}      -mcpu=$(MP_PROCESSOR_OPTION)        -D__DEBUG=__DEBUG -D__MPLAB_DEBUGGER_PK3=1  -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)   -mreserve=data@0x1000:0x101B -mreserve=data@0x101C:0x101D -mreserve=data@0x101E:0x101F -mreserve=data@0x1020:0x1021 -mreserve=data@0x1022:0x1023 -mreserve=data@0x1024:0x1027 -mreserve=data@0x1028:0x104F   -Wl,--local-stack,,--defsym=__MPLAB_BUILD=1,--defsym=__MPLAB_DEBUG=1,--defsym=__DEBUG=1,-D__DEBUG=__DEBUG,--defsym=__MPLAB_DEBUGGER_PK3=1,$(MP_LINKER_FILE_OPTION),--stack=16,--check-sections,--data-init,--pack-data,--handles,--isr,--no-gc-sections,--fill-upper=0,--stackguard=16,--no-force-link,--smart-io,-Map="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map",--report-mem,--memorysummary,dist/${CND_CONF}/${IMAGE_TYPE}/memoryfile.xml$(MP_EXTRA_LD_POST)  -mdfp="${DFP_DIR}/xc16" 
 	
 else
 dist/${CND_CONF}/${IMAGE_TYPE}/PSLab_Original.${IMAGE_TYPE}.${OUTPUT_SUFFIX}: ${OBJECTFILES}  nbproject/Makefile-${CND_CONF}.mk   
 	@${MKDIR} dist/${CND_CONF}/${IMAGE_TYPE} 
-	${MP_CC} $(MP_EXTRA_LD_PRE)  -o dist/${CND_CONF}/${IMAGE_TYPE}/PSLab_Original.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}      -mcpu=$(MP_PROCESSOR_OPTION)        -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -Wl,--local-stack,,--defsym=__MPLAB_BUILD=1,$(MP_LINKER_FILE_OPTION),--stack=16,--check-sections,--data-init,--pack-data,--handles,--isr,--no-gc-sections,--fill-upper=0,--stackguard=16,--no-force-link,--smart-io,-Map="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map",--report-mem,--memorysummary,dist/${CND_CONF}/${IMAGE_TYPE}/memoryfile.xml$(MP_EXTRA_LD_POST) 
-	${MP_CC_DIR}/xc16-bin2hex dist/${CND_CONF}/${IMAGE_TYPE}/PSLab_Original.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX} -a  -omf=elf  
+	${MP_CC} $(MP_EXTRA_LD_PRE)  -o dist/${CND_CONF}/${IMAGE_TYPE}/PSLab_Original.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}      -mcpu=$(MP_PROCESSOR_OPTION)        -omf=elf -DXPRJ_default=$(CND_CONF)  -no-legacy-libc  $(COMPARISON_BUILD)  -Wl,--local-stack,,--defsym=__MPLAB_BUILD=1,$(MP_LINKER_FILE_OPTION),--stack=16,--check-sections,--data-init,--pack-data,--handles,--isr,--no-gc-sections,--fill-upper=0,--stackguard=16,--no-force-link,--smart-io,-Map="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map",--report-mem,--memorysummary,dist/${CND_CONF}/${IMAGE_TYPE}/memoryfile.xml$(MP_EXTRA_LD_POST)  -mdfp="${DFP_DIR}/xc16" 
+	${MP_CC_DIR}/xc16-bin2hex dist/${CND_CONF}/${IMAGE_TYPE}/PSLab_Original.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX} -a  -omf=elf   -mdfp="${DFP_DIR}/xc16" 
 	
 endif
 

--- a/PSLab_Original/nbproject/Makefile-local-default.mk
+++ b/PSLab_Original/nbproject/Makefile-local-default.mk
@@ -14,23 +14,24 @@
 # You can invoke make with the values of the macros:
 # $ makeMP_CC="/opt/microchip/mplabc30/v3.30c/bin/pic30-gcc" ...  
 #
-PATH_TO_IDE_BIN=/opt/microchip/mplabx/v3.60/mplab_ide/platform/../mplab_ide/modules/../../bin/
+PATH_TO_IDE_BIN=/opt/microchip/mplabx/v5.45/mplab_platform/platform/../mplab_ide/modules/../../bin/
 # Adding MPLAB X bin directory to path.
-PATH:=/opt/microchip/mplabx/v3.60/mplab_ide/platform/../mplab_ide/modules/../../bin/:$(PATH)
+PATH:=/opt/microchip/mplabx/v5.45/mplab_platform/platform/../mplab_ide/modules/../../bin/:$(PATH)
 # Path to java used to run MPLAB X when this makefile was created
-MP_JAVA_PATH="/opt/microchip/mplabx/v3.60/sys/java/jre1.8.0_121/bin/"
+MP_JAVA_PATH="/opt/microchip/mplabx/v5.45/sys/java/zulu8.40.0.25-ca-fx-jre8.0.222-linux_x64/bin/"
 OS_CURRENT="$(shell uname -s)"
-MP_CC="/opt/microchip/xc16/v1.31/bin/xc16-gcc"
+MP_CC="/opt/microchip/xc16/v1.60/bin/xc16-gcc"
 # MP_CPPC is not defined
 # MP_BC is not defined
-MP_AS="/opt/microchip/xc16/v1.31/bin/xc16-as"
-MP_LD="/opt/microchip/xc16/v1.31/bin/xc16-ld"
-MP_AR="/opt/microchip/xc16/v1.31/bin/xc16-ar"
-DEP_GEN=${MP_JAVA_PATH}java -jar "/opt/microchip/mplabx/v3.60/mplab_ide/platform/../mplab_ide/modules/../../bin/extractobjectdependencies.jar"
-MP_CC_DIR="/opt/microchip/xc16/v1.31/bin"
+MP_AS="/opt/microchip/xc16/v1.60/bin/xc16-as"
+MP_LD="/opt/microchip/xc16/v1.60/bin/xc16-ld"
+MP_AR="/opt/microchip/xc16/v1.60/bin/xc16-ar"
+DEP_GEN=${MP_JAVA_PATH}java -jar "/opt/microchip/mplabx/v5.45/mplab_platform/platform/../mplab_ide/modules/../../bin/extractobjectdependencies.jar"
+MP_CC_DIR="/opt/microchip/xc16/v1.60/bin"
 # MP_CPPC_DIR is not defined
 # MP_BC_DIR is not defined
-MP_AS_DIR="/opt/microchip/xc16/v1.31/bin"
-MP_LD_DIR="/opt/microchip/xc16/v1.31/bin"
-MP_AR_DIR="/opt/microchip/xc16/v1.31/bin"
+MP_AS_DIR="/opt/microchip/xc16/v1.60/bin"
+MP_LD_DIR="/opt/microchip/xc16/v1.60/bin"
+MP_AR_DIR="/opt/microchip/xc16/v1.60/bin"
 # MP_BC_DIR is not defined
+DFP_DIR=/opt/microchip/mplabx/v5.45/packs/Microchip/dsPIC33E-GM-GP-MC-GU-MU_DFP/1.3.85

--- a/PSLab_Original/nbproject/configurations.xml
+++ b/PSLab_Original/nbproject/configurations.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configurationDescriptor version="62">
+<configurationDescriptor version="65">
   <logicalFolder name="root" displayName="root" projectFiles="true">
     <logicalFolder name="HeaderFiles"
                    displayName="Header Files"
@@ -49,9 +49,14 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>PICkit3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.31</languageToolchainVersion>
+        <languageToolchainVersion>1.60</languageToolchainVersion>
         <platform>2</platform>
       </toolsSet>
+      <packs>
+        <pack name="dsPIC33E-GM-GP-MC-GU-MU_DFP" vendor="Microchip" version="1.3.85"/>
+      </packs>
+      <ScriptingSettings>
+      </ScriptingSettings>
       <compileType>
         <linkerTool>
           <linkerLibItems>
@@ -69,6 +74,7 @@
       </compileType>
       <makeCustomizationType>
         <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
+        <makeUseCleanTarget>false</makeUseCleanTarget>
         <makeCustomizationPreStep></makeCustomizationPreStep>
         <makeCustomizationPostStepEnabled>false</makeCustomizationPostStepEnabled>
         <makeCustomizationPostStep></makeCustomizationPostStep>
@@ -138,6 +144,9 @@
         <property key="relax" value="false"/>
         <property key="warning-level" value="emit-warnings"/>
       </C30-AS>
+      <C30-CO>
+        <property key="coverage-enable" value=""/>
+      </C30-CO>
       <C30-LD>
         <property key="additional-options-use-response-files" value="false"/>
         <property key="boot-eeprom" value="no_eeprom"/>
@@ -165,6 +174,7 @@
         <property key="linker-stack" value="true"/>
         <property key="linker-symbols" value=""/>
         <property key="map-file" value="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map"/>
+        <property key="no-ivt" value="false"/>
         <property key="oXC16ld-extra-opts" value=""/>
         <property key="oXC16ld-fill-upper" value="0"/>
         <property key="oXC16ld-force-link" value="false"/>
@@ -189,8 +199,12 @@
         <property key="fast-math" value="false"/>
         <property key="generic-16-bit" value="false"/>
         <property key="legacy-libc" value="false"/>
+        <property key="mpreserve-all" value="false"/>
         <property key="oXC16glb-macros" value=""/>
+        <property key="omit-pack-options" value="1"/>
         <property key="output-file-format" value="elf"/>
+        <property key="preserve-all" value="false"/>
+        <property key="preserve-file" value=""/>
         <property key="relaxed-math" value="false"/>
         <property key="save-temps" value="false"/>
       </C30Global>

--- a/PSLab_Original/nbproject/project.xml
+++ b/PSLab_Original/nbproject/project.xml
@@ -12,6 +12,16 @@
             <asminc-extensions/>
             <sourceEncoding>ISO-8859-1</sourceEncoding>
             <make-dep-projects/>
+            <sourceRootList/>
+            <confList>
+                <confElem>
+                    <name>default</name>
+                    <type>2</type>
+                </confElem>
+            </confList>
+            <formatting>
+                <project-formatting-style>false</project-formatting-style>
+            </formatting>
         </data>
     </configuration>
 </project>


### PR DESCRIPTION
Changes made

- Changes to `DELAY_105US`
- Removed deprecated flash functions as they are not useful anyway
- Updated version number to 6
