### PR TITLE
Document serial protocol ADC commands

### DIFF
--- a/docs/CommunicationProtocol.md
+++ b/docs/CommunicationProtocol.md
@@ -8,27 +8,47 @@
 
 ## Commands
 
-The acknowledge byte is `254`.
+| Function Descriptor   | Main Cmd | Sub Cmd | Arguments              | Arg Type       | Return Data Stream     | Type        | Number of bytes    |
+| --------------------- | -------- | ------- | ---------------------- | -------------- | ---------------------- | ----------- | ------------------ |
+|                       |          |         |                        |                |                        |             |                    |
+| `GET_VERSION`         | `11`     | `5`     |                        |                | version string         | string      | terminated by `\n` |
+|                       |          |         |                        |                |                        |             |                    |
+| `CAPTURE_ONE`         | `2`      | `1`     | channel mux no.        | byte (0-136)   |                        |             |                    |
+|                       |          |         | no. samples to capture | Int (1-10000)  |                        |             |                    |
+|                       |          |         | timegap                | Int (6-65535)  | acknowledge            | byte        | 1                  |
+|                       |          |         |                        |                |                        |             |                    |
+| `CAPTURE_TWO`         | `2`      | `2`     | channel mux no.        | byte (0-136)   |                        |             |                    |
+|                       |          |         | no. samples to capture | Int (1-5000)   |                        |             |                    |
+|                       |          |         | timegap                | Int (7-65535)  | acknowledge            | byte        | 1                  |
+|                       |          |         |                        |                |                        |             |                    |
+| `CAPTURE_DMASPEED`    | `2`      | `3`     | channel mux no.        | byte (0-136)   |                        |             |                    |
+|                       |          |         | no. samples to capture | Int (1-10000)  |                        |             |                    |
+|                       |          |         | timegap                | Int (4-65535)  | acknowledge            | byte        | 1                  |
+|                       |          |         |                        |                |                        |             |                    |
+| `CAPTURE_FOUR`        | `2`      | `4`     | channel mux no.        | byte (0-136)   |                        |             |                    |
+|                       |          |         | no. samples to capture | Int (1-2500)   |                        |             |                    |
+|                       |          |         | timegap                | Int (14-65535) | acknowledge            | byte        | 1                  |
+|                       |          |         |                        |                |                        |             |                    |
+| `CONFIGURE_TRIGGER`   | `2`      | `5`     | trigger channel        | byte (0-3)     |                        |             |                    |
+|                       |          |         | trigger voltage        | Int (0-4095)   | acknowledge            | byte        | 1                  |
+|                       |          |         |                        |                |                        |             |                    |
+| `GET_CAPTURE_STATUS`  | `2`      | `6`     |                        |                | conversion done        | byte        | 1                  |
+|                       |          |         |                        |                | no. of samples         | Int         | 2                  |
+|                       |          |         |                        |                | acknowledge            | byte        | 1                  |
+|                       |          |         |                        |                |                        |             |                    |
+| `SET_PGA_GAIN`        | `2`      | `8`     | pga                    | byte (1-2)     |                        |             |                    |
+|                       |          |         | gain index             | byte (0-7)     | acknowledge            | byte        | 1                  |
+|                       |          |         |                        |                |                        |             |                    |
+| `GET_VOLTAGE_SUMMED`  | `2`      | `10`    | channel mux no.        | byte (0-8)     | sum of 16 samples      | Int         | 2                  |
+|                       |          |         |                        |                | acknowledge            | byte        | 1                  |
+|                       |          |         |                        |                |                        |             |                    |
+| `SET_PGA_GAIN`        | `2`      | `7`     | pga                    | byte (1-2)     |                        |             |                    |
+|                       |          |         | gain index             | byte (0-7)     | acknowledge            | byte        | 1                  |
+|                       |          |         |                        |                |                        |             |                    |
+| `SET_CAP`             | `2`      | `21`    | state                  | byte (0-1)     |                        |             |                    |
+|                       |          |         | charge time            | Int (0-65535)  | acknowledge            | byte        | 1                  |
+|                       |          |         |                        |                |                        |             |                    |
 
-| Function Descriptor   | Main Cmd | Sub Cmd | Arguments             | Arg Type     | Return Data Stream     | Type        | Number of bytes    |
-| --------------------- | -------- | ------- | --------------------- | ------------ | ---------------------- | ----------- | ------------------ |
-| `READ_BULK_FLASH`     | `1`      | `4`     | no. of bytes to read  | Int (0-2048) | values stored in flash | byte stream | N                  |
-|                       |          |         | page number           | byte (0-19)  | acknowledge            | byte        | 1                  |
-|                       |          |         |                       |              |                        |             |                    |
-| `WRITE_BULK_FLASH`    | `1`      | `3`     | no. of bytes to write | Int (0-2048) |                        | byte stream | N                  |
-|                       |          |         | page number           | byte (0-19)  | acknowledge            | byte        | 1                  |
-|                       |          |         |                       |              |                        |             |                    |
-| `get_version`         | `11`     | `5`     |                       |              | version string         | string      | terminated by `\n` |
-
-## Example `read_bulk_flash`
-
-1) Send `chr(1),chr(4)` (i.e., `0x14`?)
-2) Send number of bytes to read `chr(N&0xFF),chr((N>>8)&0xFF)`
-   (so `N`'s low byte's compliment to `0xFF`, followed by high byte's compliment
-   to `0xFF`, i.e. binary compliment of swapped bytes?)
-3) Send Page Number `chr(0-19)` (i.e. `0x01`..`0x13`?)
-4) read `N` bytes (TODO: how?)
-5) Read 1 byte and check if equals `254` (so that is a parity byte?)
 
 ## Example `get version`
 


### PR DESCRIPTION
Add ADC commands to serial protocol documentation. Only commands which are used in pslab-python have been added. The following commands are omitted:

`GET_CAPTURE_CHANNEL` (0x07): Superfluous, does the same thing as `COMMON` -> `RETRIEVE_BUFFER`

`GET_VOLTAGE` (0x09): `GET_VOLTAGE_SUMMED` is better.

`SELECT_PGA_CHANNEL` (0x0C): I don't know what it does.

`CAPTURE_12BIT`: Superfluous, same thing can be achieved with `CAPTURE_DMASPEED`.

`SET_HI_CAPTURE` (0x0F): Implements a specific experiment, which can be performed using combinations of other commands instead.

 `SET_LO_CAPTURE` (0x10): As above.

`MULTIPOINT_CAPACITANCE` (0x14): As above.

`PULSE_TRAIN` (0x16): As above.