### PR TITLE
Fix bootloader hang

### DIFF
--- a/pslab-bootloader.X/delay.c
+++ b/pslab-bootloader.X/delay.c
@@ -1,0 +1,14 @@
+#define FCY (_XTAL_FREQ / 2)
+
+
+#include <libpic30.h>
+#include "mcc_generated_files/clock.h"
+
+
+void DELAY_ms(unsigned long d) {
+    __delay_ms(d);
+}
+
+void DELAY_us(unsigned long d) {
+    __delay_us(d);
+}

--- a/pslab-bootloader.X/delay.h
+++ b/pslab-bootloader.X/delay.h
@@ -1,0 +1,26 @@
+/**
+ * @file delay.h
+ * @brief Delay functions.
+ *
+ * This file contains wrapper functions for the compiler built in delay
+ * functions. The reason for this is that other files which need to use delays
+ * can include just a single file, delay.h, instead of needing to both define
+ * FCY and import <libpic30.h>.
+ */
+
+#ifndef DELAY_H
+#define	DELAY_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+void DELAY_ms(unsigned long d);
+void DELAY_us(unsigned long d);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* DELAY_H */
+

--- a/pslab-bootloader.X/main.c
+++ b/pslab-bootloader.X/main.c
@@ -18,7 +18,7 @@
 
 int main(void)
 {
-    // initialize the device
+    // Initialize the device.
     SYSTEM_Initialize();
     
     Light_RGB(20, 0, 0);
@@ -30,6 +30,10 @@ int main(void)
     Light_RGB(20, 20, 20);
     Delay_Mili(5000);
     
+    GPIO_PIN_SetDigitalOutput();
+    GPIO_PIN_SetHigh();
+    DELAY_us(1000); // Wait for GPIO to go high.
+    
     // If GPIO is grounded or no application is detected, stay in bootloader.
     if (GPIO_PIN_GetValue() && BOOT_Verify()) {
         BOOT_StartApplication();
@@ -40,7 +44,7 @@ int main(void)
             // Monitor serial bus for commands, e.g. flashing new application.
             BOOT_ProcessCommand();
 
-            // Flash system LED while in bootloader mode.
+            // Blink system LED while in bootloader mode.
             if (!i++) STATUS_LED_Toggle();
         }
     }

--- a/pslab-bootloader.X/main.c
+++ b/pslab-bootloader.X/main.c
@@ -1,7 +1,7 @@
 /**
  * @file main.c
  * @brief PSLab bootloader.
- * 
+ *
  * The bootloader loads the main application, if one exists. If the GPIO pin
  * (RC5) is grounded, the device will stay in bootloader mode even if an
  * application exists. While in bootloader mode, a new application can be
@@ -10,30 +10,28 @@
 
 #include "mcc_generated_files/system.h"
 #include "mcc_generated_files/boot/boot_process.h"
-#include "mcc_generated_files/clock.h"
 #include "mcc_generated_files/pin_manager.h"
-#include "mcc_generated_files/watchdog.h"
 
+#include "delay.h"
 #include "rgb_led.h"
 
 int main(void)
 {
     // Initialize the device.
     SYSTEM_Initialize();
-    
+
     Light_RGB(20, 0, 0);
-    Delay_Mili(2000);
+    DELAY_ms(200);
     Light_RGB(0, 20, 0);
-    Delay_Mili(2000);
+    DELAY_ms(200);
     Light_RGB(0, 0, 20);
-    Delay_Mili(2000);
+    DELAY_ms(200);
     Light_RGB(20, 20, 20);
-    Delay_Mili(5000);
-    
+
     GPIO_PIN_SetDigitalOutput();
     GPIO_PIN_SetHigh();
     DELAY_us(1000); // Wait for GPIO to go high.
-    
+
     // If GPIO is grounded or no application is detected, stay in bootloader.
     if (GPIO_PIN_GetValue() && BOOT_Verify()) {
         BOOT_StartApplication();

--- a/pslab-bootloader.X/main.c
+++ b/pslab-bootloader.X/main.c
@@ -1,50 +1,13 @@
 /**
-  Generated main.c file from MPLAB Code Configurator
-
-  @Company
-    Microchip Technology Inc.
-
-  @File Name
-    main.c
-
-  @Summary
-    This is the generated main.c using PIC24 / dsPIC33 / PIC32MM MCUs.
-
-  @Description
-    This source file provides main entry point for system initialization and application code development.
-    Generation Information :
-        Product Revision  :  PIC24 / dsPIC33 / PIC32MM MCUs - 1.170.0
-        Device            :  PIC24EP256GP204
-    The generated drivers are tested against the following:
-        Compiler          :  XC16 v1.61
-        MPLAB 	          :  MPLAB X v5.45
+ * @file main.c
+ * @brief PSLab bootloader.
+ * 
+ * The bootloader loads the main application, if one exists. If the GPIO pin
+ * (RC5) is grounded, the device will stay in bootloader mode even if an
+ * application exists. While in bootloader mode, a new application can be
+ * flashed with the Unified Bootloader Host Application, or a similar tool.
  */
 
-/*
-    (c) 2020 Microchip Technology Inc. and its subsidiaries. You may use this
-    software and any derivatives exclusively with Microchip products.
-
-    THIS SOFTWARE IS SUPPLIED BY MICROCHIP "AS IS". NO WARRANTIES, WHETHER
-    EXPRESS, IMPLIED OR STATUTORY, APPLY TO THIS SOFTWARE, INCLUDING ANY IMPLIED
-    WARRANTIES OF NON-INFRINGEMENT, MERCHANTABILITY, AND FITNESS FOR A
-    PARTICULAR PURPOSE, OR ITS INTERACTION WITH MICROCHIP PRODUCTS, COMBINATION
-    WITH ANY OTHER PRODUCTS, OR USE IN ANY APPLICATION.
-
-    IN NO EVENT WILL MICROCHIP BE LIABLE FOR ANY INDIRECT, SPECIAL, PUNITIVE,
-    INCIDENTAL OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND
-    WHATSOEVER RELATED TO THE SOFTWARE, HOWEVER CAUSED, EVEN IF MICROCHIP HAS
-    BEEN ADVISED OF THE POSSIBILITY OR THE DAMAGES ARE FORESEEABLE. TO THE
-    FULLEST EXTENT ALLOWED BY LAW, MICROCHIP'S TOTAL LIABILITY ON ALL CLAIMS IN
-    ANY WAY RELATED TO THIS SOFTWARE WILL NOT EXCEED THE AMOUNT OF FEES, IF ANY,
-    THAT YOU HAVE PAID DIRECTLY TO MICROCHIP FOR THIS SOFTWARE.
-
-    MICROCHIP PROVIDES THIS SOFTWARE CONDITIONALLY UPON YOUR ACCEPTANCE OF THESE
-    TERMS.
- */
-
-/**
-  Section: Included Files
- */
 #include "mcc_generated_files/system.h"
 #include "mcc_generated_files/boot/boot_process.h"
 #include "mcc_generated_files/clock.h"
@@ -53,9 +16,6 @@
 
 #include "rgb_led.h"
 
-/*
-                         Main application
- */
 int main(void)
 {
     // initialize the device
@@ -87,7 +47,3 @@ int main(void)
 
     return 1;
 }
-/**
- End of File
- */
-

--- a/pslab-bootloader.X/mcc_generated_files/clock.c
+++ b/pslab-bootloader.X/mcc_generated_files/clock.c
@@ -73,11 +73,3 @@ void CLOCK_Initialize(void) {
     while (OSCCONbits.OSWEN != 0);
     while (OSCCONbits.LOCK != 1);
 }
-
-void Delay_Mili(unsigned long d) {
-    __delay32(d * (_XTAL_FREQ) / 1000ULL);
-}
-
-void Delay_Micro(unsigned long d) {
-    __delay32(d * (_XTAL_FREQ) / 1000000ULL);
-}

--- a/pslab-bootloader.X/mcc_generated_files/clock.h
+++ b/pslab-bootloader.X/mcc_generated_files/clock.h
@@ -73,9 +73,6 @@
  */
 void CLOCK_Initialize(void);
 
-void Delay_Mili(unsigned long);
-void Delay_Micro(unsigned long);
-
 #endif	/* CLOCK_H */
 /**
  End of File

--- a/pslab-bootloader.X/nbproject/configurations.xml
+++ b/pslab-bootloader.X/nbproject/configurations.xml
@@ -65,6 +65,8 @@
       </logicalFolder>
       <itemPath>main.c</itemPath>
       <itemPath>rgb_led.c</itemPath>
+      <itemPath>delay.c</itemPath>
+      <itemPath>delay.h</itemPath>
     </logicalFolder>
     <logicalFolder name="ExternalFiles"
                    displayName="Important Files"


### PR DESCRIPTION
This fixes three problems with the bootloader:

1. The device should remain in bootloader mode if the GPIO pin is low, even if an application has been flashed to the device. This is currently not the case; if an application has been flashed, it is unconditionally loaded even if the GPIO pin is low.
2. The voltage at the GPIO pin is not guaranteed to be high, so the device may stay in bootloader mode even if the GPIO pin is not grounded (disregarding issue 1).
3. The bootloader mode currently hangs in the [empty while loop](https://github.com/fossasia/pslab-firmware/blob/fdb712ae07de4fdd2acf96ad3a1a658b127643e5/pslab-bootloader.X/main.c#L80). This prevents it from responding to serial commands from the Unified Bootloader Host Application, so flashing an application is currently not possible.
