### PR TITLE
feat: generate sine and square waves simultaneously 

### DIFF
--- a/pslab-core.X/commands.c
+++ b/pslab-core.X/commands.c
@@ -168,7 +168,7 @@ command_func_t* const cmd_table[NUM_PRIMARY_CMDS + 1][NUM_SECONDARY_CMDS_MAX + 1
      // 0                            1 SET_WG                 2                             3 SET_SQR1
         Undefined,                   Unimplemented,           Undefined,                    WAVEGENERATOR_SetSquare1,
      // 4 SET_SQR2                   5 SET_SQRS               6                             7 SQR4
-        WAVEGENERATOR_SetSquare2,    Removed,                 Undefined,                    Unimplemented,
+        WAVEGENERATOR_SetSquare2,    Removed,                 Undefined,                    WAVEGENERATOR_SetSquareAll,
      // 8 MAP_REFERENCE              9 SET_WG_PHASE           10 SET_WAVEFORM_TYPE          11 SELECT_FREQ_REGISTER
         Unimplemented,               Unimplemented,           Unimplemented,                Unimplemented,
      // 12 DELAY_GENERATOR           13 SET_SINE1             14 SET_SINE2                  15 LOAD_WAVEFORM1

--- a/pslab-core.X/instruments/wavegenerator.c
+++ b/pslab-core.X/instruments/wavegenerator.c
@@ -304,9 +304,7 @@ response_t WAVEGENERATOR_SetSquare1(void) {
 
     T1CONbits.TCKPS = scale & 0x3;
 
-    if ((scale & 0x4) == 0) { // ...._.X..
-        RPOR5bits.RP54R = RPN_OC1_PORT;
-    }
+    RPOR5bits.RP54R = RPN_OC1_PORT;
 
     TMR1_Start();
 
@@ -319,24 +317,24 @@ response_t WAVEGENERATOR_SetSquare2(void) {
     uint16_t high_time = UART1_ReadInt();
     uint8_t scale = UART1_Read();
 
-    OC4_Initialize();
+    OC2_Initialize();
     TMR3_Initialize();
-
+    
     // Output Compare Clock Select is TMR 3
-    OC4CON1bits.OCTSEL = 0b001;
-    // Output set high when OC4TMR=0 and set low when OC4TMR=OC4R
-    OC4CON1bits.OCM = 0b110;
+    OC2CON1bits.OCTSEL = 0b001;
+    // Output set high when OC2TMR=0 and set low when OC2TMR=OC2R
+    OC2CON1bits.OCM = 0b110;
     // Timer 3 trigger event is used for synchronization
-    OC4CON2bits.SYNCSEL = 0b01101;
+    OC2CON2bits.SYNCSEL = 0b01101;
 
     // Set pulse turn on time
-    OC4_PrimaryValueSet(high_time - 1);
+    OC2_PrimaryValueSet(high_time - 1);
     // Set pulse width
     TMR3_Period16BitSet(wave_length - 1);
 
-    T3CONbits.TCKPS = scale;
+    T3CONbits.TCKPS = scale & 0x3;
 
-    RPOR5bits.RP55R = RPN_OC4_PORT;
+    RPOR5bits.RP55R = RPN_OC2_PORT;
 
     TMR3_Start();
 

--- a/pslab-core.X/instruments/wavegenerator.h
+++ b/pslab-core.X/instruments/wavegenerator.h
@@ -52,6 +52,12 @@ extern "C" {
      * @return SUCCESS
      */
     response_t WAVEGENERATOR_SetSquare2(void);
+    
+    /**
+     * @brief Generate PWM wave from all SQR pins
+     * @return SUCCESS
+     */
+    response_t WAVEGENERATOR_SetSquareAll(void);
 
 #ifdef	__cplusplus
 }

--- a/pslab-core.X/registers/comparators/oc1.c
+++ b/pslab-core.X/registers/comparators/oc1.c
@@ -3,7 +3,6 @@
 static uint16_t gOC1Mode;
 
 void OC1_Initialize(void) {
-
     OC1_InitializeCON1();
     OC1_InitializeCON2();
     OC1RS = 0x00;

--- a/pslab-core.X/registers/comparators/oc1.h
+++ b/pslab-core.X/registers/comparators/oc1.h
@@ -1,23 +1,13 @@
 #ifndef _OC1_H
 #define _OC1_H
 
-/**
-  Section: Included Files
- */
-
 #include <xc.h>
 #include <stdint.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus  // Provide C++ Compatibility
-
 extern "C" {
-
 #endif
-
-    /**
-      Section: Data Types
-     */
 
     /** OC1 Fault Number
 
@@ -95,7 +85,7 @@ extern "C" {
      */
 
     void OC1_Initialize(void);
-    
+
     void OC1_InitializeCON1(void);
     void OC1_InitializeCON2(void);
 
@@ -387,9 +377,7 @@ extern "C" {
     void OC1_TriggerStatusClear(void);
 
 #ifdef __cplusplus  // Provide C++ Compatibility
-
 }
-
 #endif
 
 #endif //_OC1_H

--- a/pslab-core.X/registers/comparators/oc2.c
+++ b/pslab-core.X/registers/comparators/oc2.c
@@ -3,7 +3,6 @@
 static uint16_t gOC2Mode;
 
 void OC2_Initialize(void) {
-    
     OC2_InitializeCON1();
     OC2_InitializeCON2();
     OC2RS = 0x00;

--- a/pslab-core.X/registers/comparators/oc2.h
+++ b/pslab-core.X/registers/comparators/oc2.h
@@ -1,23 +1,13 @@
 #ifndef _OC2_H
 #define _OC2_H
 
-/**
-  Section: Included Files
- */
-
 #include <xc.h>
 #include <stdint.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus  // Provide C++ Compatibility
-
 extern "C" {
-
 #endif
-
-    /**
-      Section: Data Types
-     */
 
     /** OC2 Fault Number
 
@@ -95,7 +85,7 @@ extern "C" {
      */
 
     void OC2_Initialize(void);
-    
+
     void OC2_InitializeCON1(void);
     void OC2_InitializeCON2(void);
 
@@ -387,9 +377,7 @@ extern "C" {
     void OC2_TriggerStatusClear(void);
 
 #ifdef __cplusplus  // Provide C++ Compatibility
-
 }
-
 #endif
 
 #endif //_OC2_H

--- a/pslab-core.X/registers/comparators/oc3.h
+++ b/pslab-core.X/registers/comparators/oc3.h
@@ -1,23 +1,13 @@
 #ifndef _OC3_H
 #define _OC3_H
 
-/**
-  Section: Included Files
- */
-
 #include <xc.h>
 #include <stdint.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus  // Provide C++ Compatibility
-
 extern "C" {
-
 #endif
-
-    /**
-      Section: Data Types
-     */
 
     /** OC3 Fault Number
 
@@ -338,9 +328,7 @@ extern "C" {
     void OC3_TriggerStatusClear(void);
 
 #ifdef __cplusplus  // Provide C++ Compatibility
-
 }
-
 #endif
 
 #endif //_OC3_H

--- a/pslab-core.X/registers/comparators/oc4.c
+++ b/pslab-core.X/registers/comparators/oc4.c
@@ -5,16 +5,14 @@ static uint16_t gOC4Mode;
 void OC4_Initialize(void) {
     OC4_InitializeCON1();
     OC4_InitializeCON2();
-    // OC4RS 0; 
     OC4RS = 0x00;
-    // OC4R 0; 
     OC4R = 0x00;
 
     gOC4Mode = OC4CON1bits.OCM;
 }
 
 void OC4_InitializeCON1(void) {
-    // Output Compare 3 continues to operate in CPU Idle mode
+    // Output Compare 4 continues to operate in CPU Idle mode
     OC4CON1bits.OCSIDL = 0;
     // Output Compare Clock Select is T2CLK
     OC4CON1bits.OCTSEL = 0b000;
@@ -37,9 +35,9 @@ void OC4_InitializeCON2(void) {
     OC4CON2bits.FLTMD = 0;
     // PWM output is driven low on a Fault
     OC4CON2bits.FLTOUT = 0;
-    // OC3 pin I/O state is defined by the FLTOUT bit on a Fault condition
+    // OC4 pin I/O state is defined by the FLTOUT bit on a Fault condition
     OC4CON2bits.FLTTRIEN = 0;
-    // OC3 output is not inverted
+    // OC4 output is not inverted
     OC4CON2bits.OCINV = 0;
     // Cascade module operation is disabled
     OC4CON2bits.OC32 = 0;
@@ -47,7 +45,7 @@ void OC4_InitializeCON2(void) {
     OC4CON2bits.OCTRIG = 0;
     // Timer source has not been triggered and is being held clear
     OC4CON2bits.TRIGSTAT = 0;
-    // Output Compare 3 module drives the OC3 pin
+    // Output Compare 4 module drives the OC4 pin
     OC4CON2bits.OCTRIS = 0;
     // No Sync or Trigger source
     OC4CON2bits.SYNCSEL = 0b00000;

--- a/pslab-core.X/registers/comparators/oc4.h
+++ b/pslab-core.X/registers/comparators/oc4.h
@@ -1,23 +1,13 @@
 #ifndef _OC4_H
 #define _OC4_H
 
-/**
-  Section: Included Files
- */
-
 #include <xc.h>
 #include <stdint.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus  // Provide C++ Compatibility
-
 extern "C" {
-
 #endif
-
-    /**
-      Section: Data Types
-     */
 
     /** OC4 Fault Number
 
@@ -387,9 +377,7 @@ extern "C" {
     void OC4_TriggerStatusClear(void);
 
 #ifdef __cplusplus  // Provide C++ Compatibility
-
 }
-
 #endif
 
 #endif //_OC4_H


### PR DESCRIPTION
Now user can generate both square and sine waves at the same time. This wasn't the case with previous firmware.

> Follow up: need to implement SQR1 and SQR2 generate functions in pslab-python. Previous py version had it, but now there's only SQR4 method.