### PR TITLE
feat: oscilloscope capture one channel

### DIFF
--- a/pslab-core.X/commands.c
+++ b/pslab-core.X/commands.c
@@ -1,6 +1,8 @@
 #include "commands.h"
+#include "helpers/buffer.h"
 #include "helpers/version.h"
 #include "instruments/multimeter.h"
+#include "instruments/oscilloscope.h"
 #include "instruments/wavegenerator.h"
 #include "registers/system/pin_manager.h"
 
@@ -87,9 +89,9 @@ command_func_t* const cmd_table[NUM_PRIMARY_CMDS + 1][NUM_SECONDARY_CMDS_MAX + 1
     },
     { // 2 ADC
      // 0                          1 CAPTURE_ONE                2 CAPTURE_TWO                   3 CAPTURE_DMASPEED
-        Undefined,                 Unimplemented,               Unimplemented,                  Unimplemented,
+        Undefined,                 OSCILLOSCOPE_CaptureOne,     Unimplemented,                  Unimplemented,
      // 4 CAPTURE_FOUR             5 CONFIGURE_TRIGGER          6 GET_CAPTURE_STATUS            7 GET_CAPTURE_CHANNEL
-        Unimplemented,             Unimplemented,               Unimplemented,                  Unimplemented,
+        Unimplemented,             Unimplemented,               OSCILLOSCOPE_GetCaptureStatus,  Unimplemented,
      // 8 SET_PGA_GAIN             9 GET_VOLTAGE                10 GET_VOLTAGE_SUMMED           11 START_ADC_STREAMING
         Unimplemented,             MULTIMETER_GetVoltage,       MULTIMETER_GetVoltageSummed,    Removed,
      // 12 SELECT_PGA_CHANNEL      13 CAPTURE_12BIT             14 CAPTURE_MULTIPLE             15 SET_HI_CAPTURE
@@ -105,7 +107,7 @@ command_func_t* const cmd_table[NUM_PRIMARY_CMDS + 1][NUM_SECONDARY_CMDS_MAX + 1
      // 0               1 START_SPI           2 SEND_SPI8        3 SEND_SPI16
         Undefined,      Unimplemented,        Unimplemented,     Unimplemented,
      // 4 STOP_SPI      5 SET_SPI_PARAMETERS  6 SEND_SPI8_BURST  7 SEND_SPI16_BURST
-        Unimplemented,  Unimplemented,    Removed,           Removed,
+        Unimplemented,  Unimplemented,        Removed,           Removed,
      // 8               9                     10                 11
         Undefined,      Undefined,            Undefined,         Undefined,
      // 12              13                    14                 15
@@ -235,7 +237,7 @@ command_func_t* const cmd_table[NUM_PRIMARY_CMDS + 1][NUM_SECONDARY_CMDS_MAX + 1
      // 4 GET_INDUCTANCE                 5 GET_VERSION             6                     7
         Unimplemented,                   VERSION_GetVersion,       Undefined,            Undefined,
      // 8 RETRIEVE_BUFFER                9 GET_HIGH_FREQUENCY      10 CLEAR_BUFFER       11 SETRGB
-        Unimplemented,                   Unimplemented,            Unimplemented,        Unimplemented,
+        BUFFER_Retrieve,                 Unimplemented,            Unimplemented,        Unimplemented,
      // 12 READ_PROGRAM_ADDRESS          13 WRITE_PROGRAM_ADDRESS  14 READ_DATA_ADDRESS  15 WRITE_DATA_ADDRESS
         Unimplemented,                   Unimplemented,            Unimplemented,        Unimplemented,
      // 16 GET_CAP_RANGE                 17 SETRGB2                18 READ_LOG           19 RESTORE_STANDALONE

--- a/pslab-core.X/helpers/buffer.c
+++ b/pslab-core.X/helpers/buffer.c
@@ -1,0 +1,17 @@
+#include "../bus/uart/uart1.h"
+#include "../commands.h"
+#include "../registers/system/pin_manager.h"
+
+// Space in memory to store data.
+int16_t volatile __attribute__((section(".adc_buffer"), far)) BUFFER[10000];
+
+response_t BUFFER_Retrieve(void) {
+    int16_t volatile* idx = &BUFFER[UART1_ReadInt()];
+    int16_t volatile* end = idx + UART1_ReadInt();
+
+    while (idx != end) UART1_WriteInt(*(idx++));
+    
+    LED_SetHigh();
+    
+    return SUCCESS;
+}

--- a/pslab-core.X/helpers/buffer.h
+++ b/pslab-core.X/helpers/buffer.h
@@ -1,0 +1,31 @@
+#ifndef BUFFER_H
+#define	BUFFER_H
+
+#include <stdint.h>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+    extern int16_t volatile __attribute__((section(".adc_buffer"), far)) BUFFER[10000];
+    
+    /**
+    * @brief
+    * Send buffer contents.
+    * 
+    * @description
+    * This command function takes two arguments over serial:
+    * 1. The starting index in the buffer from which to send values.
+    * 2. The number of values to be sent.
+    * It returns the requested data over serial.
+    * It sends an acknowledge byte (SUCCESS)
+    * 
+    * @return SUCCESS
+    */
+    response_t BUFFER_Retrieve(void);
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* BUFFER_H */

--- a/pslab-core.X/helpers/light.h
+++ b/pslab-core.X/helpers/light.h
@@ -20,7 +20,7 @@ extern "C" {
      */
     void LIGHT_RGB(uint8_t red, uint8_t green, uint8_t blue);
 
-
+    
 #ifdef	__cplusplus
 }
 #endif

--- a/pslab-core.X/instruments/oscilloscope.c
+++ b/pslab-core.X/instruments/oscilloscope.c
@@ -1,0 +1,120 @@
+#include <stdint.h>
+#include "../registers/converters/adc1.h"
+#include "../registers/system/pin_manager.h"
+#include "../registers/timers/tmr5.h"
+#include "../bus/uart/uart1.h"
+#include "../helpers/buffer.h"
+#include "../commands.h"
+
+#define MAX_CHANNELS 4
+
+/* Static globals */
+static uint8_t volatile TRIGGERED = 0;
+static uint8_t volatile TRIGGER_READY = 0;
+static uint8_t TRIGGER_CHANNEL = 0;
+static uint8_t CHANNELS = 0;
+
+static uint16_t DELAY;
+static uint16_t TRIGGER_TIMEOUT = 100;
+static uint16_t volatile TRIGGER_WAITING = 0;
+static uint16_t TRIGGER_LEVEL = 0;
+static uint16_t TRIGGER_PRESCALER = 0;
+
+static int16_t volatile* volatile BUFFER_IDX[MAX_CHANNELS];
+static uint16_t volatile* ADCVALS[MAX_CHANNELS] = {
+    &ADC1BUF0, &ADC1BUF1, &ADC1BUF2, &ADC1BUF3
+};
+static uint16_t volatile SAMPLES_CAPTURED;
+static uint16_t SAMPLES_REQUESTED;
+
+/* Static function prototypes */
+static void ResetTrigger(void);
+static void Setup10BitMode(void);
+
+/**
+ * @brief Handle trigger and data collection from ADC.
+ * 
+ * @description
+ * This interrupt handler is called every time the ADC finishes a conversion, if
+ * the ADC interrupt is enabled. It checks if the trigger condition is
+ * fulfilled, and if so copies ADC values into the buffer.
+ */
+void __attribute__((interrupt, no_auto_psv)) _AD1Interrupt(void) {
+    uint16_t adval;
+    int i;
+    
+    ADC1_InterruptFlagClear();
+    LED_SetHigh();
+    
+    if (TRIGGERED) {
+        for (i = 0; i <= CHANNELS; i++) *(BUFFER_IDX[i]++) = *ADCVALS[i];
+        
+        SAMPLES_CAPTURED++;
+        LED_SetLow();
+        if (SAMPLES_CAPTURED == SAMPLES_REQUESTED) {
+            ADC1_InterruptDisable();
+            LED_SetHigh();
+        }
+    } else {
+        for (i = 0; i < MAX_CHANNELS; i++) {
+            if (TRIGGER_CHANNEL & 1 << i) adval = *ADCVALS[i];
+        }
+
+        // If the trigger hasn't timed out, check for trigger condition.
+        if (TRIGGER_WAITING < TRIGGER_TIMEOUT) {
+            TRIGGER_WAITING += (DELAY >> TRIGGER_PRESCALER);
+            if (!TRIGGER_READY && adval > TRIGGER_LEVEL + 10)TRIGGER_READY = 1;
+            else if (adval <= TRIGGER_LEVEL && TRIGGER_READY) {
+                TRIGGERED = 1;
+            }
+        }
+        // If the trigger has timed out, then proceed to data acquisition.
+        else {
+            TRIGGERED = 1;
+        }
+    }
+}
+
+response_t OSCILLOSCOPE_CaptureOne(void) {
+    uint8_t pin = UART1_Read();
+    SAMPLES_REQUESTED = UART1_ReadInt();
+    DELAY = UART1_ReadInt();
+
+    CHANNELS = 0; //capture one channel
+    AD1CON2bits.CHPS = 0;
+    ADC1_SetOperationMode(ADC1_10BIT_SIMULTANEOUS_MODE, pin & 0x7F, 0);
+    AD1CON2bits.CHPS = 0;
+
+    if (pin & 0x80) ResetTrigger();
+    else TRIGGERED = 1;
+
+    SAMPLES_CAPTURED = 0;
+    BUFFER_IDX[0] = &BUFFER[0];
+    Setup10BitMode();
+    ADC1_InterruptFlagClear();
+    ADC1_InterruptEnable();
+    LED_SetLow();
+    
+    return SUCCESS;
+}
+
+static void ResetTrigger(void) {
+    TRIGGER_WAITING = 0;
+    TRIGGER_READY = 0;
+    TRIGGERED = 0;
+}
+
+static void Setup10BitMode(void) {
+    T5CONbits.TCKPS = 1;
+    TMR5_Period16BitSet(DELAY - 1);
+    TMR5 = 0;
+    TMR5_Start();
+}
+
+response_t OSCILLOSCOPE_GetCaptureStatus(void) {
+    uint8_t conversion_done;
+    conversion_done = SAMPLES_CAPTURED == SAMPLES_REQUESTED ? 1 : 0;
+    UART1_Write(conversion_done);
+    UART1_WriteInt(SAMPLES_CAPTURED);
+    return SUCCESS;
+}

--- a/pslab-core.X/instruments/oscilloscope.h
+++ b/pslab-core.X/instruments/oscilloscope.h
@@ -1,6 +1,32 @@
 #ifndef OSCILLOSCOPE_H
 #define	OSCILLOSCOPE_H
 
+/**
+ * @brief Capture samples on a single channel.
+ * 
+ * @description
+ * This command function takes three arguments over serial:
+ * 1. (uint8) The pin to sample
+ * 2. (uint16) The number of samples to capture
+ * 3. (uint16) The time to wait between samples in instruction cycles
+ * It returns nothing over serial.
+ * It sends an acknowledge byte (SUCCESS).
+ */
+response_t OSCILLOSCOPE_CaptureOne(void);
 
+/**
+ * @brief
+ * Send capture progress.
+ * 
+ * @description
+ * This command function takes no arguments over serial.
+ * It returns two values over serial:
+ * 1. (bool) True if all requested samples have been captured.
+ * 2. (uint16) Number of captured samples.
+ * It sends an acknowledge byte (SUCCESS).
+ * 
+ * @return SUCCESS
+ */
+response_t OSCILLOSCOPE_GetCaptureStatus(void);
 
 #endif	/* OSCILLOSCOPE_H */

--- a/pslab-core.X/nbproject/configurations.xml
+++ b/pslab-core.X/nbproject/configurations.xml
@@ -24,6 +24,7 @@
         <itemPath>helpers/light.h</itemPath>
         <itemPath>helpers/delay.h</itemPath>
         <itemPath>helpers/version.h</itemPath>
+        <itemPath>helpers/buffer.h</itemPath>
       </logicalFolder>
       <logicalFolder name="instruments" displayName="instruments" projectFiles="true">
         <itemPath>instruments/multimeter.h</itemPath>
@@ -116,6 +117,7 @@
         <itemPath>helpers/light.c</itemPath>
         <itemPath>helpers/delay.c</itemPath>
         <itemPath>helpers/version.c</itemPath>
+        <itemPath>helpers/buffer.c</itemPath>
       </logicalFolder>
       <logicalFolder name="instruments" displayName="instruments" projectFiles="true">
         <itemPath>instruments/multimeter.c</itemPath>


### PR DESCRIPTION
- Move ADC1_Buffer to separate file `helpers/buffer.c`, since it is not only used to store ADC values (it is also used to store timer values for the logic analyzer)
- Implement COMMON->RETRIEVE_BUFFER
- Add `LIGHT_SystemLED` to `light.h`
- Begin implementing some oscilloscope functions. For now, CAPTURE_ONE and GET_CAPTURE_STATUS are implemented.

Outstanding issues:
Capture does not quite work. The buffer does get written to, but all values are either 0 or 1. My guess is that either the ADC is not being configured correctly, or the analog inputs are being pulled low somewhere in the mcc generated files. Will investigate further, but suggestions are welcome.

Discussion points:
- Command function naming. I noticed you changed the name of the GET_VERSION function from `VERSION_SendHw` to `VERSION_GetVersion`, @CloudyPadmal. I was thinking it makes more sense to name the functions for what they are doing from the perspective of the firmware, rather than the perspective of the user. But perhaps that is confusing and it is better to keep their names similar to the serial protocol. I don't have a strong opinion either way; as long as we agree on a standard.
- Types. Should we use built in types (unsigned int etc.) or stdint (uint16_t etc.)? Right now we're using a mix of both. I tend to prefer built ins simply to avoid the extra include, but I'm perfectly fine with using stdint as well.