### PR TITLE
Add UART SET_MODE command to set stop_bits, bits_per_word and parity.

### DIFF
--- a/PSLab_Original/PSLAB_UART.c
+++ b/PSLab_Original/PSLAB_UART.c
@@ -7,6 +7,10 @@
 BYTE c1 = 0;
 BYTE c2 = 0;
 
+uint16 UART2_BRG = BRGVAL1000000;
+BYTE UART2_ST = 0; //1 stop bit
+BYTE UART2_PD = 0; //no parity, 8-data bits
+
 void __attribute__((__interrupt__, no_auto_psv)) _U2RXInterrupt(void) {
     asm("CLRWDT");
     //while (U1STAbits.UTXBF); //wait for transmit buffer empty
@@ -100,18 +104,18 @@ uint16 getInt() {
     return (c2 << 8) | c1;
 }
 
-void configUART2(uint16 BAUD) {
+void configUART2(void) {
     _TRISB5 = 0;
     _TRISB6 = 1;
     RPOR1bits.RP37R = 0x03;
     RPINR19bits.U2RXR = 38;
 
-    U2MODEbits.STSEL = 0; //1 stop bit
-    U2MODEbits.PDSEL = 0; //no parity, 8-data bits
+    U2MODEbits.STSEL = UART2_ST;
+    U2MODEbits.PDSEL = UART2_PD;
     U2MODEbits.ABAUD = 0; //disable auto-baud
     U2MODEbits.BRGH = 1; //high speed mode
 
-    U2BRG = BAUD;
+    U2BRG = UART2_BRG;
 
     U2MODEbits.UEN = 0;
     U2MODEbits.RTSMD = 1;
@@ -166,7 +170,8 @@ void sendAddress2(char address) { //9-bit mode only
 /*----UART 2 on SCL, SDA----------------*/
 void initUART2_passthrough(uint16 BAUD) {
     /*---------UART2 pass through------------*/
-    configUART2(BAUD);
+    UART2_BRG = BAUD
+    configUART2();
     _U1RXIE = 1; //enable receive interrupt for UART1
     _U2RXIE = 1; //enable receive interrupt for UART2
 

--- a/PSLab_Original/PSLAB_UART.h
+++ b/PSLab_Original/PSLAB_UART.h
@@ -11,6 +11,9 @@
 extern BYTE c1;
 extern BYTE c2;
 
+extern uint16 UART2_BRG;
+extern BYTE UART2_ST, UART2_PD;
+
 extern void initUART(uint16);
 extern bool hasChar();
 extern void sendChar(BYTE val);
@@ -20,7 +23,7 @@ extern char getChar();
 extern uint16 getInt();
 extern void ack(BYTE);
 
-extern void configUART2(uint16 BAUD);
+extern void configUART2(void);
 extern bool hasChar2(void);
 extern char getChar2(void);
 extern uint16 getInt2(void);

--- a/PSLab_Original/proto2_main.c
+++ b/PSLab_Original/proto2_main.c
@@ -501,7 +501,7 @@ int main() {
                         break;
 
                     case SET_MODE:
-                        sendChar(1); // Let host know SET_MODE subcommand is supported
+                        sendChar(4); // Let host know SET_MODE subcommand is supported
                         value = getChar(); // stop_bit, pd, 00000
                         UART2_ST = (value)&0x1;
                         UART2_PD = (value >> 1)&0x3;

--- a/PSLab_Original/proto2_main.c
+++ b/PSLab_Original/proto2_main.c
@@ -496,7 +496,16 @@ int main() {
 
                     case SET_BAUD:
                         lsb = getInt();
-                        configUART2(lsb);
+                        UART2_BRG = lsb;
+                        configUART2();
+                        break;
+
+                    case SET_MODE:
+                        sendChar(1); // Let host know SET_MODE subcommand is supported
+                        value = getChar(); // stop_bit, pd, 00000
+                        UART2_ST = (value)&0x1;
+                        UART2_PD = (value >> 1)&0x3;
+                        configUART2();
                         break;
 
                 }


### PR DESCRIPTION
Additional function to support `pslab.bus.busio.UART`.

> SET_MODE command is already present in `COMMANDS.h`. But it is missing in main loop.

> Is it necessary to reset these before uart_passthrough? OR uart_passthrough supports two uart with different config.
>> Like: UART1(8bit, no_parity, 1stop_bit) = UART2(8bit, even_parity, 2stop_bit)