### PR TITLE
feat: Implement oscilloscope DMA capture

### DIFF
--- a/pslab-core.X/commands.c
+++ b/pslab-core.X/commands.c
@@ -89,17 +89,17 @@ command_func_t* const cmd_table[NUM_PRIMARY_CMDS + 1][NUM_SECONDARY_CMDS_MAX + 1
     },
     { // 2 ADC
      // 0                          1 CAPTURE_ONE                  2 CAPTURE_TWO                   3 CAPTURE_DMASPEED
-        Undefined,                 OSCILLOSCOPE_CaptureOne,       OSCILLOSCOPE_CaptureTwo,        Unimplemented,
+        Undefined,                 OSCILLOSCOPE_CaptureOne,       OSCILLOSCOPE_CaptureTwo,        OSCILLOSCOPE_CaptureDMA,
      // 4 CAPTURE_FOUR             5 CONFIGURE_TRIGGER            6 GET_CAPTURE_STATUS            7 GET_CAPTURE_CHANNEL
         OSCILLOSCOPE_CaptureFour,  OSCILLOSCOPE_ConfigureTrigger, OSCILLOSCOPE_GetCaptureStatus,  Unimplemented,
      // 8 SET_PGA_GAIN             9 GET_VOLTAGE                  10 GET_VOLTAGE_SUMMED           11 START_ADC_STREAMING
         OSCILLOSCOPE_SetPGAGain,   MULTIMETER_GetVoltage,         MULTIMETER_GetVoltageSummed,    Removed,
      // 12 SELECT_PGA_CHANNEL      13 CAPTURE_12BIT               14 CAPTURE_MULTIPLE             15 SET_HI_CAPTURE
-        Unimplemented,             Unimplemented,                 Removed,                        Unimplemented,
+        Unimplemented,             Unimplemented,                 Removed,                        Removed,
      // 16 SET_LO_CAPTURE          17 SET_HI_CAPTURE12            18 SET_LO_CAPTURE12             19 CAPTURE_DMASPEED12
-        Unimplemented,             Unimplemented,                 Unimplemented,                  Unimplemented,
+        Removed,                   Removed,                       Removed,                        Removed,
      // 20 MULTIPOINT_CAPACITANCE  21 SET_CAP                     22 PULSE_TRAIN                  23 CAPTURE_THREE
-        Unimplemented,             Unimplemented,                 Unimplemented,                  OSCILLOSCOPE_CaptureThree,
+        Removed,                   Unimplemented,                 Removed,                        OSCILLOSCOPE_CaptureThree,
      // 24                         25                             26                              27
         Undefined,                 Undefined,                     Undefined,                      Undefined,
     },

--- a/pslab-core.X/instruments/oscilloscope.h
+++ b/pslab-core.X/instruments/oscilloscope.h
@@ -52,6 +52,35 @@ response_t OSCILLOSCOPE_CaptureThree(void);
 response_t OSCILLOSCOPE_CaptureFour(void);
 
 /**
+ * @brief Capture samples on one channel as fast as possible.
+ * 
+ * @description
+ * Direct memory access moves samples from ADC to RAM buffer as soon as
+ * conversion is complete. Allows for faster sample rate than using ADC
+ * interrupt, at the cost of only supporting a single channel and no trigger.
+ * This command function takes three arguments over serial:
+ * 1. (uint8)  Configuration byte:
+ *             | 7   | 6 | 5 | 4 | 3 | 2 | 1 | 0 |
+ *             | RES | - | - | - |     CH0SA     |
+ *             RES: Sample resolution:
+ *                  0: 10-bit,
+ *                  1: 12-bit,                        
+ *             CH0SA: First channel input map:
+ *                    3: CH1,
+ *                    0: CH2,
+ *                    1: CH3,
+ *                    2: MIC,
+ *                    7: RES,
+ *                    5: CAP,
+ *                    8: VOL,
+ * 2. (uint16) The number of samples to capture.
+ * 3. (uint16) The time to wait between samples in instruction cycles.
+ * It returns nothing over serial.
+ * It sends an acknowledge byte (SUCCESS).
+ */
+response_t OSCILLOSCOPE_CaptureDMA(void);
+
+/**
  * @brief
  * Send capture progress.
  *

--- a/pslab-core.X/registers/converters/adc1.h
+++ b/pslab-core.X/registers/converters/adc1.h
@@ -63,6 +63,33 @@ extern "C" {
         ADC1_CTMU_MODE
     } ADC1_PSLAB_MODES;
 
+    /** ADC sample trigger source
+ 
+     @Summary 
+       Defines the trigger source that ends sampling and starts conversion.
+ 
+     @Description
+       The MSB is set on the SSRCG register and the three LSBs are set on the
+       SSRC register.
+ 
+     */
+    typedef enum {
+        ADC1_MANUAL_SOURCE            = 0b0000,
+        ADC1_INT0_SOURCE              = 0b0001,
+        ADC1_TMR3_SOURCE              = 0b0010,
+        ADC1_PWM_SPECIAL_EVENT_SOURCE = 0b0011,
+        ADC1_TMR5_SOURCE              = 0b0100,
+        ADC1_CTMU_SOURCE              = 0b0110,
+        ADC1_INTERNAL_CTR_SOURCE      = 0b0111,
+        ADC1_PWM_GEN1_SOURCE          = 0b1000,
+        ADC1_PWM_GEN2_SOURCE          = 0b1001,
+        ADC1_PWM_GEN3_SOURCE          = 0b1010,
+        ADC1_PTGO12_SOURCE            = 0b1011,
+        ADC1_PTGO13_SOURCE            = 0b1100,
+        ADC1_PTGO14_SOURCE            = 0b1101,
+        ADC1_PTGO15_SOURCE            = 0b1110,
+    } ADC1_SAMPLE_TRIGGER_SOURCE;
+    
     /**
       Section: Interface Routines
      */
@@ -877,6 +904,32 @@ extern "C" {
         AD1CON1bits.ASAM = 0;
     }
 
+        /**
+      @Summary
+         Selects the trigger source that ends sampling and starts conversion.
+
+      @Description
+        This routine is used to select a trigger source for the ADC. When
+        triggered, the ADC stop sampling and starts conversion.
+  
+      @Preconditions
+        ADC1_Initialize() function should have been 
+        called before calling this function.
+ 
+      @Returns
+        None
+
+      @Param
+        Pass in required trigger source from ADC1_SAMPLE_TRIGGER_SOURCE list.
+  
+      @Example
+        ADC1_SelectSampleTrigger(ADC1_TMR5_SOURCE); // TMR5 compare ends sampling and starts conversion.
+     */
+    inline static void ADC1_SelectSampleTrigger(ADC1_SAMPLE_TRIGGER_SOURCE source) {
+        AD1CON1bits.SSRCG = source >> 3;
+        AD1CON1bits.SSRC = source;
+    }
+    
     /**
       @Summary
         Allows conversion clock prescaler value to be set

--- a/pslab-core.X/registers/memory/dma.h
+++ b/pslab-core.X/registers/memory/dma.h
@@ -69,7 +69,7 @@ extern "C" {
         DMA_PERIPHERAL_IRQ_IC1 = 0x1,
         DMA_PERIPHERAL_IRQ_INT0 = 0x0,
     } DMA_PERIPHERAL_IRQ_NUMBER;
-
+    
     /**
       Section: Interface Routines
      */
@@ -320,7 +320,47 @@ extern "C" {
             default: break;
         }
     }
+    
+    /**
+     @Summary
+      Enables one-shot mode.
 
+     @Description
+      This routine is used to enable one-shot mode on a channel in the DMA. In
+      one-shot mode, the channel is automatically disabled after finishing
+      moving the data block.
+ 
+    @Preconditions
+     DMA_Initializer() function should have been 
+     called before calling this function.
+ 
+    @Returns
+     None
+
+    @Param
+     Pass in the required channel from the DMA_CHANNEL list.
+  
+    @Example
+     DMA_SetOneShotMode(DMA_CHANNEL_0); // Set one-shot mode on DMA0.
+     */
+    inline static void DMA_SetOneShotMode(DMA_CHANNEL channel) {
+        switch (channel) {
+            case DMA_CHANNEL_0:
+                DMA0CONbits.MODE |= 0b01;
+                break;
+            case DMA_CHANNEL_1:
+                DMA1CONbits.MODE |= 0b01;
+                break;
+            case DMA_CHANNEL_2:
+                DMA2CONbits.MODE |= 0b01;
+                break;
+            case DMA_CHANNEL_3:
+                DMA3CONbits.MODE |= 0b01;
+                break;
+            default: break;
+        }
+    }
+    
     /**
       @Summary
         Sets the transfer count of the DMA

--- a/pslab-core.X/registers/timers/tmr5.h
+++ b/pslab-core.X/registers/timers/tmr5.h
@@ -11,6 +11,21 @@ extern "C" {
 
     /**
       @Summary
+       List of available prescalers.
+
+      @Description
+       These prescalers can be passed to the TMR5_SetPrescaler routine in order to
+       slow down the TMR by a certain factor.
+     */
+    typedef enum {
+        TMR5_PRESCALER_1,
+        TMR5_PRESCALER_8,
+        TMR5_PRESCALER_64,
+        TMR5_PRESCALER_256,
+    } TMR5_PRESCALER;
+
+    /**
+      @Summary
         Initializes hardware and data for the given instance of the TMR module
 
       @Description
@@ -118,6 +133,74 @@ extern "C" {
         None
      */
     void TMR5_Stop(void);
+    
+    /**
+      @Summary
+        Stops the TMR when MCU idles.
+
+      @Description
+        This routine stops the TMR when the MCU is in idle mode.
+
+      @Param
+        None.
+
+      @Returns
+        None
+     */
+    inline static void TMR5_StopWhenIdle(void) {
+        T5CONbits.TSIDL = 1;
+    }
+    
+    /**
+      @Summary
+       Slows down the TMR.
+
+      @Description
+        This routine sets a prescaler which slows down the TMR by a factor.
+
+      @Param
+        Pass the desired prescaler from the TMR5_PRESCALER list.
+
+      @Returns
+        None
+     */
+    inline static void TMR5_SetPrescaler(TMR5_PRESCALER prescaler) {
+        T5CONbits.TCKPS = prescaler;
+    }
+
+    /**
+      @Summary
+        Disables the TMR interrupt.
+
+      @Description
+        This routine disables the TMR interrupt.
+
+      @Param
+        None.
+
+      @Returns
+        None
+     */
+    inline static void TMR5_InterruptDisable(void) {
+        IEC1bits.T5IE = 0;
+    }
+    
+    /**
+      @Summary
+        Clears the TMR interrupt flag.
+
+      @Description
+        This routine clears the TMR interrupt flag.
+
+      @Param
+        None.
+
+      @Returns
+        None
+     */   
+    inline static void TMR5_InterruptFlagClear(void) {
+        IFS1bits.T5IF = 0;
+    }
 
 #ifdef __cplusplus  // Provide C++ Compatibility
 }


### PR DESCRIPTION
With this, the new firmware is at feature parity with the old firmware as far as the oscilloscope is concerned.

I have marked several command functions as `removed` in `commands.c`:
```
15 SET_HI_CAPTURE
16 SET_LO_CAPTURE
17 SET_HI_CAPTURE12 
18 SET_LO_CAPTURE12
19 CAPTURE_DMASPEED12
20 MULTIPOINT_CAPACITANCE
22 PULSE_TRAIN
```
These functions either implement specific experiments which should not be implemented in firmware, or (in the case of `CAPTURE_DMASPEED12`) are instead run by passing an argument to `CAPTURE_DMASPEED`.