### PR TITLE
feat: uart2 passthrough

### DIFF
--- a/pslab-core.X/bus/uart/uart1.c
+++ b/pslab-core.X/bus/uart/uart1.c
@@ -4,30 +4,26 @@
 
 void __attribute__((__interrupt__, no_auto_psv)) _U1RXInterrupt(void) {
     WATCHDOG_TimerClear();
+    // Wait until UART2 finish sending out data
     while (U2STAbits.UTXBF);
+    // Load what's received from UART1 interface to UART2 transmit buffer
     U2TXREG = U1RXREG;
-    _U1RXIF = 0;
-}
-
-void __attribute__((__interrupt__, no_auto_psv)) _U2RXInterrupt(void) {
-    WATCHDOG_TimerClear();
-    while (U1STAbits.UTXBF);
-    U1TXREG = U2RXREG;
-    _U2RXIF = 0;
+    // Clear the interrupt flag and await more data from UART1 interface
+    UART1_InterruptFlagClear();
 }
 
 void UART1_Initialize(void) {
-    // UARTx is disabled; all UARTx pins are controlled by PORT latches; 
-    // UARTx power consumption is minimal
+    // UART1 is disabled; all UART1 pins are controlled by PORT latches; 
+    // UART1 power consumption is minimal
     U1MODEbits.UARTEN = 0;
     // Continues module operation in Idle mode
     U1MODEbits.USIDL = 0;
     // IrDA encoder and decoder are disabled
     U1MODEbits.IREN = 0;
-    // UxRTS pin is in Flow Control mode
+    // U1RTS pin is in Flow Control mode
     U1MODEbits.RTSMD = 0;
-    // UxTX and UxRX pins are enabled and used; 
-    // UxCTS and UxRTS/BCLKx pins are controlled by PORT latches
+    // U1TX and U1RX pins are enabled and used; 
+    // U1CTS and U1RTS/BCLKx pins are controlled by PORT latches
     U1MODEbits.UEN = 0b00;
     // No wake-up is enabled
     U1MODEbits.WAKE = 0;
@@ -35,7 +31,7 @@ void UART1_Initialize(void) {
     U1MODEbits.LPBACK = 0;
     // Baud rate measurement is disabled or completed
     U1MODEbits.ABAUD = 0;
-    // UxRX Idle state is '1'
+    // U1RX Idle state is '1'
     U1MODEbits.URXINV = 0;
     // BRG generates 16 clocks per bit period (16x baud clock, Standard mode)
     U1MODEbits.BRGH = 1;
@@ -48,7 +44,7 @@ void UART1_Initialize(void) {
     // :this implies there is at least one character open in the transmit buffer
     U1STAbits.UTXISEL1 = 0;
     U1STAbits.UTXISEL0 = 0;
-    // UxTX Idle state is '1'
+    // U1TX Idle state is '1'
     U1STAbits.UTXINV = 0;
     // Sync Break transmission is disabled or completed
     U1STAbits.UTXBRK = 0;
@@ -60,7 +56,7 @@ void UART1_Initialize(void) {
     // Transmit Shift Register isn't empty, a transmission is in progress/queued
     U1STAbits.TRMT = 0;
     // Interrupt is set when any character is received and transferred from the 
-    // UxRSR to the receive buffer; receive buffer has one or more characters
+    // U1RSR to the receive buffer; receive buffer has one or more characters
     U1STAbits.URXISEL = 0b00;
     // Address Detect mode is disabled
     U1STAbits.ADDEN = 0;
@@ -76,7 +72,7 @@ void UART1_Initialize(void) {
     // Receive buffer is empty
     U1STAbits.URXDA = 0;
 
-    // UxBRG = [FCY / (16 * BAUD)] - 1
+    // U1BRG = [FCY / (16 * BAUD)] - 1
     // BaudRate = 1000000; Frequency = 64000000 Hz; BRG 15;
     U1BRG = 0x0F;
 

--- a/pslab-core.X/bus/uart/uart1.h
+++ b/pslab-core.X/bus/uart/uart1.h
@@ -3,6 +3,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <xc.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -232,6 +233,18 @@ extern "C" {
      *   None.
      */
     void UART1_ClearBuffer(void);
+    
+    inline static void UART1_InterruptEnable(void) {
+        IEC0bits.U1RXIE = 1;
+    }
+    
+    inline static void UART1_InterruptDisable(void) {
+        IEC0bits.U1RXIE = 0;
+    }
+    
+    inline static void UART1_InterruptFlagClear(void) {
+        IFS0bits.U1RXIF = 0;
+    }
 
 #ifdef __cplusplus  // Provide C++ Compatibility
 }

--- a/pslab-core.X/bus/uart/uart2.c
+++ b/pslab-core.X/bus/uart/uart2.c
@@ -1,21 +1,91 @@
 #include <xc.h>
 #include "uart2.h"
+#include "uart1.h"
+#include "../../registers/system/pin_manager.h"
+#include "../../registers/system/watchdog.h"
+#include "../../helpers/delay.h"
+#include "../../commands.h"
 
-void UART2_Initialize(void) {
-    /**    
-         Set the UART2 module to the options selected in the user interface.
-         Make sure to set LAT bit corresponding to TxPin as high before UART initialization
-     */
-    // STSEL 1; IREN disabled; PDSEL 8N; UARTEN enabled; RTSMD disabled; USIDL disabled; WAKE disabled; ABAUD disabled; LPBACK disabled; BRGH enabled; URXINV disabled; UEN TX_RX; 
-    // Data Bits = 8; Parity = None; Stop Bits = 1;
-    U2MODE = (0x8008 & ~(1 << 15)); // disabling UARTEN bit
-    // UTXISEL0 TX_ONE_CHAR; UTXINV disabled; OERR NO_ERROR_cleared; URXISEL RX_ONE_CHAR; UTXBRK COMPLETED; UTXEN disabled; ADDEN disabled; 
-    U2STA = 0x00;
-    // BaudRate = 460800; Frequency = 64000000 Hz; BRG 34; 
-    U2BRG = 0x22;
 
-    U2MODEbits.UARTEN = 1; // enabling UART ON bit
-    U2STAbits.UTXEN = 1;
+static uint16_t UART2_BAUD_RATE = 0x0F;
+void SetUART2_BAUD_RATE(uint16_t V) { UART2_BAUD_RATE = V; }
+uint16_t GetUART2_BAUD_RATE(void) { return UART2_BAUD_RATE; }
+
+void __attribute__((__interrupt__, no_auto_psv)) _U2RXInterrupt(void) {
+    WATCHDOG_TimerClear();
+    // Wait until UART1 finish sending out data
+    while (U1STAbits.UTXBF);
+    // Load what's received from UART2 interface to UART1 transmit buffer
+    U1TXREG = U2RXREG;
+    // Clear the interrupt flag and await more data from UART2 interface
+    UART2_InterruptFlagClear();
+}
+
+void UART2_Initialize() {
+    // UART2 is disabled; all UART2 pins are controlled by PORT latches; 
+    // UART2 power consumption is minimal
+    U2MODEbits.UARTEN = 0;
+    // Continues module operation in Idle mode
+    U2MODEbits.USIDL = 0;
+    // IrDA encoder and decoder are disabled
+    U2MODEbits.IREN = 0;
+    // U2RTS pin is in Simplex mode
+    U2MODEbits.RTSMD = 1;
+    // U2TX and U2RX pins are enabled and used; 
+    // U2CTS and U2RTS/BCLKx pins are controlled by PORT latches
+    U2MODEbits.UEN = 0b00;
+    // No wake-up is enabled
+    U2MODEbits.WAKE = 0;
+    // Loop-back mode is disabled
+    U2MODEbits.LPBACK = 0;
+    // Baud rate measurement is disabled or completed
+    U2MODEbits.ABAUD = 0;
+    // U2RX Idle state is '1'
+    U2MODEbits.URXINV = 0;
+    // BRG generates 16 clocks per bit period (16x baud clock, Standard mode)
+    U2MODEbits.BRGH = 1;
+    // 8-bit data, no parity
+    U2MODEbits.PDSEL = 0b00;
+    // One Stop bit
+    U2MODEbits.STSEL = 0;
+
+    // Interrupt when a character is transferred to the Transmit Shift Register 
+    // :this implies there is at least one character open in the transmit buffer
+    U2STAbits.UTXISEL1 = 0;
+    U2STAbits.UTXISEL0 = 0;
+    // U2TX Idle state is '1'
+    U2STAbits.UTXINV = 0;
+    // Sync Break transmission is disabled or completed
+    U2STAbits.UTXBRK = 0;
+    // Transmit is disabled, any pending transmission is aborted and buffer is
+    // reset; U2 TXpin is controlled by the PORT
+    U2STAbits.UTXEN = 0;
+    // Transmit buffer is not full, at least one more character can be written
+    U2STAbits.UTXBF = 0;
+    // Transmit Shift Register isn't empty, a transmission is in progress/queued
+    U2STAbits.TRMT = 0;
+    // Interrupt is set when any character is received and transferred from the 
+    // U2RSR to the receive buffer; receive buffer has one or more characters
+    U2STAbits.URXISEL = 0b00;
+    // Address Detect mode is disabled
+    U2STAbits.ADDEN = 0;
+    // Receiver is active
+    U2STAbits.RIDLE = 0;
+    // Parity error has not been detected
+    U2STAbits.PERR = 0;
+    // Framing error has not been detected
+    U2STAbits.FERR = 0;
+    // Receive buffer has not overflowed; clearing a previously set OERRbit
+    // (1 -> 0 transition) resets the RX buffer and U1RSR to the empty state
+    U2STAbits.OERR = 0;
+    // Receive buffer is empty
+    U2STAbits.URXDA = 0;
+
+    // U2BRG = [FCY / (16 * BAUD)] - 1
+    // BaudRate = 1000000; Frequency = 64000000 Hz; BRG 15;
+    U2BRG = GetUART2_BAUD_RATE();
+
+    UART2_Enable();
 }
 
 uint8_t UART2_Read(void) {
@@ -30,8 +100,7 @@ uint8_t UART2_Read(void) {
 
 void UART2_Write(uint8_t txData) {
     while (U2STAbits.UTXBF == 1);
-
-    U2TXREG = txData; // Write the data byte to the USART.
+    U2TXREG = txData;
 }
 
 bool UART2_IsRxReady(void) {
@@ -54,4 +123,8 @@ void UART2_Enable(void) {
 void UART2_Disable(void) {
     U2MODEbits.UARTEN = 0;
     U2STAbits.UTXEN = 0;
+}
+
+void UART2_ClearBuffer(void) {
+    while (UART2_IsRxReady()) UART2_Read();
 }

--- a/pslab-core.X/bus/uart/uart2.h
+++ b/pslab-core.X/bus/uart/uart2.h
@@ -3,6 +3,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <xc.h>
+
 
 #ifdef __cplusplus  // Provide C++ Compatibility
 extern "C" {
@@ -173,6 +175,35 @@ extern "C" {
         Refer to UART2_Initialize(); for an example
      */
     void UART2_Disable(void);
+    
+    /**
+     * @Summary
+     *   Discard incoming serial traffic
+     * 
+     * @Description
+     *   Reads out the RX buffer and clear it for incoming serial traffic at the
+     *   startup.
+     * 
+     * @Returns
+     *   None.
+     */
+    void UART2_ClearBuffer(void);
+    
+    inline static void UART2_InterruptEnable(void) {
+        IEC1bits.U2RXIE = 1;
+    }
+    
+    inline static void UART2_InterruptDisable(void) {
+        IEC1bits.U2RXIE = 0;
+    }
+    
+    inline static void UART2_InterruptFlagClear(void) {
+        IFS1bits.U2RXIF = 0;
+    }
+    
+    // Getter and Setter for UART2 baud rate parameter
+    void SetUART2_BAUD_RATE(uint16_t);
+    uint16_t GetUART2_BAUD_RATE(void);
 
 #ifdef __cplusplus  // Provide C++ Compatibility
 }

--- a/pslab-core.X/commands.c
+++ b/pslab-core.X/commands.c
@@ -23,6 +23,7 @@ unsigned char num_secondary_cmds[NUM_PRIMARY_CMDS + 1] = {
     NUM_DIN_CMDS,
     NUM_TIMING_CMDS,
     NUM_COMMON_CMDS,
+    NUM_PASSTHRU_CMDS,
 };
 
 /**
@@ -246,5 +247,21 @@ command_func_t* const cmd_table[NUM_PRIMARY_CMDS + 1][NUM_SECONDARY_CMDS_MAX + 1
         Unimplemented,                   Undefined,                Unimplemented,           Unimplemented,
      // 24 STOP_CTMU                     25 START_COUNTING         26 FETCH_COUNT           27 FILL_BUFFER
         Unimplemented,                   Unimplemented,            Unimplemented,           Unimplemented,
+    },
+    { // 12 PASSTHROUGH
+     // 0          1                        2          3
+        Undefined, DEVICE_UARTPassThrough,  Undefined, Undefined,
+     // 4          5                        6          7
+        Undefined, Undefined,               Undefined, Undefined,
+     // 8          9                        10         11
+        Undefined, Undefined,               Undefined, Undefined,
+     // 12         13                       14         15
+        Undefined, Undefined,               Undefined, Undefined,
+     // 16         17                       18         19
+        Undefined, Undefined,               Undefined, Undefined,
+     // 20         21                       22         23
+        Undefined, Undefined,               Undefined, Undefined,
+     // 24         25                       26         27
+        Undefined, Undefined,               Undefined, Undefined,
     },
 };

--- a/pslab-core.X/commands.h
+++ b/pslab-core.X/commands.h
@@ -17,7 +17,7 @@ extern "C" {
  * This is used to set the dimensions of the command table, and to sanitize
  * received commands.
  */
-#define NUM_PRIMARY_CMDS 11
+#define NUM_PRIMARY_CMDS 12
 #define NUM_FLASH_CMDS 4
 #define NUM_ADC_CMDS 23
 #define NUM_SPI_CMDS 7
@@ -29,6 +29,7 @@ extern "C" {
 #define NUM_DIN_CMDS 2
 #define NUM_TIMING_CMDS 17
 #define NUM_COMMON_CMDS 27
+#define NUM_PASSTHRU_CMDS 1
 #define NUM_SECONDARY_CMDS_MAX NUM_COMMON_CMDS // Change if necessary.
 
 /**

--- a/pslab-core.X/helpers/device.h
+++ b/pslab-core.X/helpers/device.h
@@ -29,6 +29,12 @@ extern "C" {
      * @return SUCCESS
      */
     response_t DEVICE_WriteRegisterData(void);
+    
+    /**
+     * @brief Channel UART1 and UART2 interfaces together
+     * @return SUCCESS
+     */
+    response_t DEVICE_UARTPassThrough(void);
 
 #ifdef	__cplusplus
 }


### PR DESCRIPTION
Implements a method to bridge both the UART1 and UART2 modules by tying up TX1-RX2 and RX1-TX2. This will be useful say to communicate through an ESP01 module or a Bluetooth module.

TODO:

- Python function to enable UART Passthrough function.