### PR TITLE
chore: release only the hex file

### DIFF
--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -69,5 +69,5 @@ jobs:
             - name: Publish build files
               uses: actions/upload-artifact@v2
               with:
-                name: production-files
-                path: pslab-core.X/dist/default/production/
+                name: production-file
+                path: pslab-core.X/dist/default/production/*.hex


### PR DESCRIPTION
Currently the build uploads everything in the production folder which is not necessary. The only needed file is the `.hex` file and this PR filters out to upload only that file