### PR TITLE
refactor: merge rgb command functions

### DIFF
--- a/pslab-core.X/commands.c
+++ b/pslab-core.X/commands.c
@@ -243,14 +243,14 @@ command_func_t* const cmd_table[NUM_PRIMARY_CMDS + 1][NUM_SECONDARY_CMDS_MAX + 1
         Undefined,                      Unimplemented,                  MULTIMETER_GetCapacitance,      Unimplemented,
      // 4 GET_INDUCTANCE                5 GET_VERSION                   6                               7
         Unimplemented,                  DEVICE_GetVersion,              Undefined,                      Undefined,
-     // 8 RETRIEVE_BUFFER               9 GET_HIGH_FREQUENCY            10 CLEAR_BUFFER                 11 SETRGB
-        BUFFER_Retrieve,                Unimplemented,                  Unimplemented,                  LIGHT_Onboard,
+     // 8 RETRIEVE_BUFFER               9 GET_HIGH_FREQUENCY            10 CLEAR_BUFFER                 11 SET_RGB1
+        BUFFER_Retrieve,                Unimplemented,                  Unimplemented,                  Removed,
      // 12 READ_PROGRAM_ADDRESS         13 WRITE_PROGRAM_ADDRESS        14 READ_DATA_ADDRESS            15 WRITE_DATA_ADDRESS
         Removed,                        Removed,                        DEVICE_ReadRegisterData,        DEVICE_WriteRegisterData,
-     // 16 GET_CAP_RANGE                17 SETRGB2                      18 READ_LOG                     19 RESTORE_STANDALONE
-        Unimplemented,                  LIGHT_One,                      Removed,                        DEVICE_Reset,
-     // 20 GET_ALTERNATE_HIGH_FREQUENCY 21                              22 SETRGB3                      23 START_CTMU
-        Unimplemented,                  Undefined,                      LIGHT_Two,                      Unimplemented,
+     // 16 GET_CAP_RANGE                17 SET_RGB2                     18 READ_LOG                     19 RESTORE_STANDALONE
+        Unimplemented,                  Removed,                        Removed,                        DEVICE_Reset,
+     // 20 GET_ALTERNATE_HIGH_FREQUENCY 21 SET_RGB_COMMON               22 SET_RGB3                     23 START_CTMU
+        Unimplemented,                  LIGHT_RGBPin,                   Removed,                        Unimplemented,
      // 24 STOP_CTMU                    25 START_COUNTING               26 FETCH_COUNT                  27 FILL_BUFFER
         Unimplemented,                  SENSORS_StartCounter,           SENSORS_GetCounter,             Unimplemented,
     },

--- a/pslab-core.X/helpers/light.c
+++ b/pslab-core.X/helpers/light.c
@@ -49,12 +49,19 @@
             }\
         } while(0)
 
+typedef enum {
+    ONBOARD,
+    SQR1,
+    SQR2,
+    SQR3,
+    SQR4,
+} PINSELECT;
+
 void LIGHT_RGB(uint8_t red, uint8_t green, uint8_t blue) {
     RGBCommon(red, green, blue, RGB_LED_Setter);
 }
 
-response_t LIGHT_Onboard(void) {
-    
+response_t LIGHT_RGBPin(void) {
     uint8_t count = UART1_Read();
     uint8_t colors[count];
     
@@ -62,53 +69,30 @@ response_t LIGHT_Onboard(void) {
     for (i = 0; i < count; i++) {
         colors[i] = UART1_Read();
     }
+    PINSELECT pin = UART1_Read();
     
     INTERRUPT_GlobalDisable();
     
     for (i = 0; i < count; i = i + 3) {
-        RGBCommon(colors[i+1], colors[i], colors[i+2], RGB_LED_Setter);
-    }
-    
-    INTERRUPT_GlobalEnable();
-    
-    return SUCCESS;
-}
-
-response_t LIGHT_One(void) {
-    
-    uint8_t count = UART1_Read();
-    uint8_t colors[count];
-    
-    uint8_t i;
-    for (i = 0; i < count; i++) {
-        colors[i] = UART1_Read();
-    }
-    
-    INTERRUPT_GlobalDisable();
-    
-    for (i = 0; i < count; i = i + 3) {
-        RGBCommon(colors[i+1], colors[i], colors[i+2], SQR1_Setter);
-    }
-    
-    INTERRUPT_GlobalEnable();
-    
-    return SUCCESS;
-}
-
-response_t LIGHT_Two(void) {
-    
-    uint8_t count = UART1_Read();
-    uint8_t colors[count];
-    
-    uint8_t i;
-    for (i = 0; i < count; i++) {
-        colors[i] = UART1_Read();
-    }
-    
-    INTERRUPT_GlobalDisable();
-    
-    for (i = 0; i < count; i = i + 3) {
-        RGBCommon(colors[i+1], colors[i], colors[i+2], SQR2_Setter);
+        switch (pin) {
+        case ONBOARD:
+            RGBCommon(colors[i+1], colors[i], colors[i+2], RGB_LED_Setter);
+            break;
+        case SQR1:
+            RGBCommon(colors[i+1], colors[i], colors[i+2], SQR1_Setter);
+            break;
+        case SQR2:
+            RGBCommon(colors[i+1], colors[i], colors[i+2], SQR2_Setter);
+            break;
+        case SQR3:
+            RGBCommon(colors[i+1], colors[i], colors[i+2], SQR3_Setter);
+            break;
+        case SQR4:
+            RGBCommon(colors[i+1], colors[i], colors[i+2], SQR4_Setter);
+            break;
+        default:
+            break;
+        }
     }
     
     INTERRUPT_GlobalEnable();

--- a/pslab-core.X/helpers/light.h
+++ b/pslab-core.X/helpers/light.h
@@ -25,56 +25,26 @@ extern "C" {
      * @brief Controls the on-board RGB LED
      * 
      * @description
-     * This routine takes two types of arguments over serial.
-     * 1. (uint8) count
-     *    Number of color levels. This always has to be 3. It is implemented this
-     * way to have backward compatibility with old firmware and python backend.
-     * 2. (uint8 [count]) color levels
-     *    This a sequence of bytes with the amount determined by count variable.
-     * In this case it will be three bytes in series. These will define red, green
-     * and blue colors of the LED.
-     * 
-     * It will not return anything over serial. An acknowledgment will be passed.
-     * 
-     * @return none
-     */
-    response_t LIGHT_Onboard(void);
-    
-    /**
-     * @brief Controls an RGB LED stripe from SQR1 pin
-     * 
-     * @description
-     * This routine takes two types of arguments over serial.
+     * This routine takes three types of arguments over serial.
      * 1. (uint8) count
      *    Number of color levels. This has to be a multiple of 3 since each LED 
-     * has three colors to control.
+     *    has three colors to control.
      * 2. (uint8 [count]) color levels
      *    This a sequence of bytes with the amount determined by count variable.
-     * These will define red, green and blue colors of each of the LEDs.
+     *    These will define red, green and blue colors of each of the LEDs.
+     * 3. (uint8) pin
+     *    The pin to which the RGB LED's DIN is connected.
+     *    0: Onboard RGB,
+     *    1: SQ1,
+     *    2: SQ2,
+     *    3: SQ3,
+     *    4: SQ4
      * 
      * It will not return anything over serial. An acknowledgment will be passed.
      * 
      * @return none
      */
-    response_t LIGHT_One(void);
-    
-    /**
-     * @brief Controls an RGB LED stripe from SQR2 pin
-     * 
-     * @description
-     * This routine takes two types of arguments over serial.
-     * 1. (uint8) count
-     *    Number of color levels. This has to be a multiple of 3 since each LED 
-     * has three colors to control.
-     * 2. (uint8 [count]) color levels
-     *    This a sequence of bytes with the amount determined by count variable.
-     * These will define red, green and blue colors of each of the LEDs.
-     * 
-     * It will not return anything over serial. An acknowledgment will be passed.
-     * 
-     * @return none
-     */
-    response_t LIGHT_Two(void);
+    response_t LIGHT_RGBPin(void);
     
 #ifdef	__cplusplus
 }

--- a/pslab-core.X/registers/system/pin_manager.h
+++ b/pslab-core.X/registers/system/pin_manager.h
@@ -273,6 +273,7 @@
 #define SQR2_SetDigitalInput()         (_TRISC7 = 1)
 #define SQR2_SetDigitalOutput()        (_TRISC7 = 0)
 
+#define SQR3_Setter                    _LATC8
 #define SQR3_SetHigh()                 (_LATC8 = 1)
 #define SQR3_SetLow()                  (_LATC8 = 0)
 #define SQR3_Toggle()                  (_LATC8 ^= 1)
@@ -280,6 +281,7 @@
 #define SQR3_SetDigitalInput()         (_TRISC8 = 1)
 #define SQR3_SetDigitalOutput()        (_TRISC8 = 0)
 
+#define SQR4_Setter                    _LATC9
 #define SQR4_SetHigh()                 (_LATC9 = 1)
 #define SQR4_SetLow()                  (_LATC9 = 0)
 #define SQR4_Toggle()                  (_LATC9 ^= 1)


### PR DESCRIPTION
This change removes the three commands `SET_RGB1`, `SET_RGB2`, `SET_RGB3` and replaces them with a new command, `SET_RGB_COMMON`. The new command takes one additional argument over serial: The pin where the LED is connected. Available choices are the onboard RGB LED, as well as SQ1-4.

Since the previous commands are removed, this change requires changes to pslab-python and pslab-android.