### PR TITLE
Oscilloscope bug fixes

### DIFF
--- a/pslab-core.X/instruments/oscilloscope.c
+++ b/pslab-core.X/instruments/oscilloscope.c
@@ -117,7 +117,7 @@ response_t OSCILLOSCOPE_GetCaptureStatus(void) {
 
 response_t OSCILLOSCOPE_ConfigureTrigger(void) {
     uint8_t config = UART1_Read();
-    SetTRIGGER_CHANNEL(config & 0x03);
+    SetTRIGGER_CHANNEL(config & 0x0F);
     SetTRIGGER_PRESCALER(config >> 4);
     SetTRIGGER_LEVEL(UART1_ReadInt());
     return SUCCESS;

--- a/pslab-core.X/instruments/oscilloscope.c
+++ b/pslab-core.X/instruments/oscilloscope.c
@@ -58,9 +58,12 @@ static void Capture(void) {
         SetBUFFER_IDX(i, &BUFFER[i * GetSAMPLES_REQUESTED()]);
     }
     
+    SetCONVERSION_DONE(0);
     SetSAMPLES_CAPTURED(0);
     SetBUFFER_IDX(0, &BUFFER[0]);
     SetTimeGap();
+    ADC1_InterruptFlagClear();
+    ADC1_InterruptEnable();
     LED_SetLow();
 }
 
@@ -82,7 +85,8 @@ response_t OSCILLOSCOPE_CaptureDMA(void) {
     DMA_InterruptEnable(DMA_CHANNEL_0);
     DMA_ChannelEnable(DMA_CHANNEL_0);
 
-    SetSAMPLES_CAPTURED(GetSAMPLES_REQUESTED()); // Assume it's all over already.
+    SetSAMPLES_CAPTURED(GetSAMPLES_REQUESTED());
+    SetCONVERSION_DONE(1); // Assume it's all over already.
     SetTimeGap();
     LED_SetLow();
     

--- a/pslab-core.X/registers/converters/adc1.c
+++ b/pslab-core.X/registers/converters/adc1.c
@@ -61,7 +61,7 @@ static uint16_t DELAY;
 void SetDELAY(uint16_t V) { DELAY = V; }
 uint16_t GetDELAY(void) { return DELAY; }
 
-static uint8_t CONVERSION_DONE = 1;
+static uint8_t volatile CONVERSION_DONE = 1;
 void SetCONVERSION_DONE(uint8_t V) { CONVERSION_DONE = V; }
 uint8_t GetCONVERSION_DONE(void) { return CONVERSION_DONE; }
 


### PR DESCRIPTION
The ADC ISR broke in 27f21ef, specifically by the addition of the `CONVERSION_DONE` global.