### PR TITLE
feat: trigger on non-sampled channel

### DIFF
--- a/pslab-core.X/instruments/oscilloscope.h
+++ b/pslab-core.X/instruments/oscilloscope.h
@@ -103,17 +103,19 @@ response_t OSCILLOSCOPE_GetCaptureStatus(void);
  * This command function takes two arguments over serial.
  * 1. (uint8)  Configuration byte:
  *             | 7 | 6 | 5 | 4 | 3 | 2 | 1 | 0  |
- *             |   Prescaler   | - | - |  CHSEL |
+ *             |   Prescaler   |      CHSEL     |
  *             Prescaler: The trigger times out (i.e. capture starts) after:
  *                        timeout = DELAY * (50000 / (DELAY >> prescaler)) / 8 us
  *                        If DELAY >> prescaler == 0 trigger does not time out.
  *             CHSEL: Trigger channel select.
- *                    0: Trigger on CH0SA,
- *                    1: Trigger on CH123SA[0],
- *                    2: Trigger on CH123SA[1],
- *                    3. Trigger on CH123SA[2],
- *                    Note that it is not necessary to sample the trigger
- *                    channel.
+ *                    b0000: Disable trigger,
+ *                    b0001: Trigger on CH0SA,
+ *                    b0010: Trigger on CH123SA[0],
+ *                    b0100: Trigger on CH123SA[1],
+ *                    b1000. Trigger on CH123SA[2],
+ *                    It is not necessary to sample the trigger channel, but
+ *                    the trigger channel must still be converted which affects
+ *                    the sample rate.
  * 2. (uint16) Trigger voltage.
  * It returns nothing over serial.
  *

--- a/pslab-core.X/registers/converters/adc1.c
+++ b/pslab-core.X/registers/converters/adc1.c
@@ -79,8 +79,6 @@ void SetBUFFER_IDX(uint8_t idx, volatile uint16_t *V) {
  * fulfilled, and if so copies ADC values into the buffer.
  */
 void __attribute__((interrupt, no_auto_psv)) _AD1Interrupt(void) {
-    int i;
-
     ADC1_InterruptFlagClear();
 
     if (CONVERSION_DONE) {
@@ -88,38 +86,29 @@ void __attribute__((interrupt, no_auto_psv)) _AD1Interrupt(void) {
         // triggered, but no need to process further. Hence abort and return.
         return;
     }
-    LED_SetHigh();
+    
+    LED_Toggle();
 
     if (TRIGGERED) {
-        for (i = 0; i <= CHANNELS; i++) *(BUFFER_IDX[i]++) = *ADCVALS[i];
+        int i;
+        for (i = 0; i <= CHANNELS; i++) {
+            *(BUFFER_IDX[i]++) = *ADCVALS[i];
+        }
 
-        SAMPLES_CAPTURED++;
-        LED_SetLow();
-        if (SAMPLES_CAPTURED == SAMPLES_REQUESTED) {
+        if (++SAMPLES_CAPTURED == SAMPLES_REQUESTED) {
             ADC1_InterruptDisable();
-            ADC1_InterruptFlagClear();
             CONVERSION_DONE = 1;
             LED_SetHigh();
         }
-    } else {
-        uint16_t adval;
-        for (i = 0; i < MAX_CHANNELS; i++) {
-            if (TRIGGER_CHANNEL & (1 << i)) adval = *ADCVALS[i];
-        }
-
-        // If the trigger hasn't timed out, check for trigger condition.
-        if (TRIGGER_WAITING < TRIGGER_TIMEOUT) {
-            TRIGGER_WAITING += (DELAY >> TRIGGER_PRESCALER);
-            if (!TRIGGER_READY && adval > TRIGGER_LEVEL + 10) TRIGGER_READY = 1;
-            else if (adval <= TRIGGER_LEVEL && TRIGGER_READY) {
-                TRIGGERED = 1;
-            }
-        } 
-        // If the trigger has timed out, then proceed to data acquisition.
-        else {
-            TRIGGERED = 1;
-        }
+        return;
     }
+
+    // Trigger timed out, proceed to data acquisition.
+    TRIGGERED |= TRIGGER_WAITING >= TRIGGER_TIMEOUT;
+    TRIGGER_WAITING += DELAY >> TRIGGER_PRESCALER;
+    TRIGGER_READY |= *ADCVALS[TRIGGER_CHANNEL] > TRIGGER_LEVEL;
+    // Trigger condition met, proceed to data acquisition.
+    TRIGGERED |= TRIGGER_READY && *ADCVALS[TRIGGER_CHANNEL] <= TRIGGER_LEVEL;
 }
 
 void ADC1_Initialize(void) {


### PR DESCRIPTION
This is needed by TCD1304 in order to sync the oscilloscope with the clocks driving the sensor.