### PR TITLE
feat: get capacitor range

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -252,7 +252,7 @@ command_func_t* const cmd_table[NUM_PRIMARY_CMDS + 1][NUM_SECONDARY_CMDS_MAX + 1
      // 12 READ_PROGRAM_ADDRESS         13 WRITE_PROGRAM_ADDRESS        14 READ_DATA_ADDRESS            15 WRITE_DATA_ADDRESS
         Removed,                        Removed,                        DEVICE_ReadRegisterData,        DEVICE_WriteRegisterData,
      // 16 GET_CAP_RANGE                17 SET_RGB2                     18 READ_LOG                     19 RESTORE_STANDALONE
-        Unimplemented,                  Removed,                        Removed,                        DEVICE_Reset,
+        MULTIMETER_GetCapRange,         Removed,                        Removed,                        DEVICE_Reset,
      // 20 GET_ALTERNATE_HIGH_FREQUENCY 21 SET_RGB_COMMON               22 SET_RGB3                     23 START_CTMU
         Unimplemented,                  LIGHT_RGBPin,                   Removed,                        CTMU_Start,
      // 24 STOP_CTMU                    25 START_COUNTING               26 FETCH_COUNT                  27 FILL_BUFFER

--- a/src/instruments/multimeter.h
+++ b/src/instruments/multimeter.h
@@ -28,7 +28,23 @@ extern "C" {
      * @return SUCCESS
      */
     response_t MULTIMETER_GetCapacitance(void);
-    
+
+    /**
+     * @brief Get an estimate of the capacitor range
+     *
+     * @description
+     * This function can be used to get an estimate of how large a 
+     * capacitor is. One use case could be to compare two different
+     * capacitors without having to evaluate the exact capacitance.
+     * This command takes only one argument over serial:
+     * 1. (uint16) Charge time in micro seconds
+     *
+     * It returns the range value as uint16.
+     *
+     * @return SUCCESS
+     */
+    response_t MULTIMETER_GetCapRange(void);
+
     /**
      * @brief Measurements using Charge Time Measurement Unit
      *


### PR DESCRIPTION
## Porting get capacitor range function

This function can be used to get an estimate of how large the capacitance is. It doesn't yield anything `pF`. Instead it outputs a numerical value. This could be used to compare two objects wrt to their capacitance.

The following figure shows how this numerical output varies wrt to charging time. As charging time increases, the range seems to converge to a flat value.

<img src="https://user-images.githubusercontent.com/14261304/192052214-aed2e2fa-06fb-4ca2-8485-2b4c3ae2f389.png" width=100% />