### PR TITLE
feat: porting spi basic module functions

### DIFF
--- a/src/bus/spi/CMakeLists.txt
+++ b/src/bus/spi/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(pslab-firmware.elf PRIVATE
+  spi1.c
   spi_driver.c
   spi_master.c
 )

--- a/src/bus/spi/spi1.c
+++ b/src/bus/spi/spi1.c
@@ -1,0 +1,141 @@
+#include <xc.h>
+#include <string.h>
+#include "spi1.h"
+#include "../spi/spi_driver.h"
+#include "../uart/uart1.h"
+#include "../../registers/system/pin_manager.h"
+
+uint8_t volatile __attribute__((section(".spi_buffer"), far)) SPI_BUFFER[SPI_BUFFER_SIZE];
+
+static SPI1_PARAMETERS parameters = {
+    SPI1_MODE_BYTE,
+    SPI1_DATA_SAMPLE_AT_END,
+    SPI1_CLOCK_EDGE_ACTIVE_TO_IDLE,
+    SPI1_CLOCK_POLARITY_IDLE_LOW,
+    SPI1_SECONDARY_PRESCALER_6_TO_1,
+    SPI1_PRIMARY_PRESCALER_64_TO_1
+};
+
+void SPI1_Initialize(void) {
+
+    // Disable SPI module and clear flags
+    SPI1STAT = 0x0000;
+    // Set SPI configurations
+    SPI1CON1bits.PPRE = parameters.primaryPrescaler;
+    SPI1CON1bits.SPRE = parameters.secondaryPrescaler;
+    // Enable internal clock
+    SPI1CON1bits.DISSCK = 0;
+    // Module controls SDO
+    SPI1CON1bits.DISSDO = 0;
+    // CS pin not used
+    SPI1CON1bits.SSEN = 0;
+    SPI1CON1bits.MODE16 = parameters.spiMode;
+    SPI1CON1bits.CKE = parameters.clockEdge;
+    SPI1CON1bits.CKP = parameters.clockPolarity;
+    // Module is the master
+    SPI1CON1bits.MSTEN = 1;
+    SPI1CON1bits.SMP = parameters.dataSample;
+    // Clear frame settings
+    SPI1CON2 = 0x0000;
+}
+
+response_t SPI1_SetParameters(void) {
+
+    uint8_t configuration = UART1_Read();
+
+    parameters.clockEdge = (configuration >> 5) & 1;
+    parameters.clockPolarity = (configuration >> 6) & 1;
+    parameters.dataSample = (configuration >> 7) & 1;
+    parameters.secondaryPrescaler = configuration & 0b111;
+    parameters.primaryPrescaler = (configuration >> 3) & 0b11;
+
+    SPI1_Initialize();
+
+    SPI1_EnableModule();
+
+    return SUCCESS;
+}
+
+response_t SPI1_Start(void) {
+
+    SPI1_ChipSelect();
+
+    return DO_NOT_BOTHER;
+}
+
+response_t SPI1_Stop(void) {
+
+    SPI1_ChipDeselect();
+
+    return DO_NOT_BOTHER;
+}
+
+void SPI1_ByteOperations(SPI1_OPERATION op, uint16_t count, uint8_t address) {
+
+    uint16_t i;
+    uint16_t turns = count;
+    if (op == SPI1_OPERATION_READ) {
+        turns = turns + 1;
+        memset((void *) &SPI_BUFFER[1], 0x00, turns);
+        SPI_BUFFER[0] = address;
+    } else {
+        for (i = 0; i < turns; i++) {
+            SPI_BUFFER[i] = UART1_Read();
+        }
+    }
+
+    if (parameters.spiMode != SPI1_MODE_BYTE) {
+        parameters.spiMode = SPI1_MODE_BYTE;
+        SPI1_Initialize();
+    }
+    SPI1_EnableModule();
+
+    SPI1_ChipSelect();
+    SPI_DRIVER_ExchangeBlock((void *) SPI_BUFFER, turns);
+    SPI1_ChipDeselect();
+
+    if (op == SPI1_OPERATION_EXCHANGE) {
+        for (i = 1; i < turns; i++) {
+            UART1_Write(SPI_BUFFER[i]);
+        }
+    } else if (op == SPI1_OPERATION_READ) {
+        for (i = 1; i <= count; i++) {
+            UART1_Write(SPI_BUFFER[i]);
+        }
+    }
+}
+
+response_t SPI1_Write8(void) {
+
+    SPI1_ByteOperations(SPI1_OPERATION_WRITE, 2, 0);
+
+    return SUCCESS;
+}
+
+response_t SPI1_Write8Burst(void) {
+
+    uint16_t count = UART1_ReadInt();
+
+    SPI1_ByteOperations(SPI1_OPERATION_WRITE, count, 0);
+
+    return SUCCESS;
+}
+
+response_t SPI1_Send8Burst(void) {
+
+    uint16_t count = UART1_ReadInt();
+
+    SPI1_ByteOperations(SPI1_OPERATION_EXCHANGE, count, 0);
+
+    return SUCCESS;
+}
+
+response_t SPI1_Read8Burst(void) {
+
+    uint8_t address = UART1_Read();
+    uint16_t count = UART1_ReadInt();
+
+    SPI1_ByteOperations(SPI1_OPERATION_READ, count, address);
+
+    return SUCCESS;
+}

--- a/src/bus/spi/spi1.h
+++ b/src/bus/spi/spi1.h
@@ -1,0 +1,248 @@
+#ifndef SPI1_H
+#define SPI1_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <xc.h>
+
+#include "../../commands.h"
+
+#define SPI_BUFFER_SIZE     1000
+
+#define SPI1_ChipSelect()   CS_SPI_SetLow()
+#define SPI1_ChipDeselect() CS_SPI_SetHigh()
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    typedef enum {
+        SPI1_PRIMARY_PRESCALER_1_TO_1           = 0b11,
+        SPI1_PRIMARY_PRESCALER_4_TO_1           = 0b10,
+        SPI1_PRIMARY_PRESCALER_16_TO_1          = 0b01,
+        SPI1_PRIMARY_PRESCALER_64_TO_1          = 0b00
+    } SPI1_PRIMARY_PRESCALER;
+
+    typedef enum {
+        SPI1_SECONDARY_PRESCALER_1_TO_1         = 0b111,
+        SPI1_SECONDARY_PRESCALER_2_TO_1         = 0b110,
+        SPI1_SECONDARY_PRESCALER_3_TO_1         = 0b101,
+        SPI1_SECONDARY_PRESCALER_4_TO_1         = 0b100,
+        SPI1_SECONDARY_PRESCALER_5_TO_1         = 0b011,
+        SPI1_SECONDARY_PRESCALER_6_TO_1         = 0b010,
+        SPI1_SECONDARY_PRESCALER_7_TO_1         = 0b001,
+        SPI1_SECONDARY_PRESCALER_8_TO_1         = 0b000
+    } SPI1_SECONDARY_PRESCALER;
+
+    typedef enum {
+        SPI1_MODE_BYTE,
+        SPI1_MODE_WORD
+    } SPI1_MODE;
+
+    typedef enum {
+        SPI1_DATA_SAMPLE_AT_MIDDLE,
+        SPI1_DATA_SAMPLE_AT_END
+    } SPI1_DATA_SAMPLE;
+
+    typedef enum {
+        SPI1_CLOCK_EDGE_IDLE_TO_ACTIVE,
+        SPI1_CLOCK_EDGE_ACTIVE_TO_IDLE
+    } SPI1_CLOCK_EDGE;
+
+    typedef enum {
+        SPI1_CLOCK_POLARITY_IDLE_LOW,
+        SPI1_CLOCK_POLARITY_IDLE_HIGH
+    } SPI1_CLOCK_POLARITY;
+
+    typedef enum {
+        SPI1_OPERATION_WRITE,
+        SPI1_OPERATION_READ,
+        SPI1_OPERATION_EXCHANGE
+    } SPI1_OPERATION;
+
+    typedef struct {
+        SPI1_MODE spiMode;
+        SPI1_DATA_SAMPLE dataSample;
+        SPI1_CLOCK_EDGE clockEdge;
+        SPI1_CLOCK_POLARITY clockPolarity;
+        SPI1_SECONDARY_PRESCALER secondaryPrescaler;
+        SPI1_PRIMARY_PRESCALER primaryPrescaler;
+    } SPI1_PARAMETERS;
+
+    inline static void SPI1_EnableModule(void) {
+        SPI1STATbits.SPIEN = 1;
+    }
+
+    inline static void SPI1_DisableModule(void) {
+        SPI1STATbits.SPIEN = 0;
+    }
+
+    /**
+     * @brief Initialize SPI routine with the set SPI1_PARAMETERS
+     * @return None
+     */
+    void SPI1_Initialize(void);
+
+    /**
+     * @brief Set chip select on SPI header extension
+     *
+     * @description
+     * This method takes nothing over serial
+     *
+     * @return DO_NOT_BOTHER
+     */
+    response_t SPI1_Start(void);
+
+    /**
+     * @brief Unset chip select on SPI header extension
+     *
+     * @description
+     * This method takes nothing over serial
+     *
+     * @return DO_NOT_BOTHER
+     */
+    response_t SPI1_Stop(void);
+
+    /**
+     * @brief Configure module parameters for SPI
+     *
+     * @description
+     * This method updates the configuration registers for SPI module
+     * and enables the module for SPI communication protocol.
+     * This command function takes one argument over serial:
+     * 1. (uint8)  Configuration byte:
+     *             | 7  | 6  | 5  | 4 | 3 | 2 | 1 | 0 |
+     *             | DS | CP | CE | P-PRE |   S-PRE   |
+     *             DS: Data sampling point
+     *             CP: Clock polarity
+     *             CE: Clock edge definition
+     *             P-PRE: Primary pre-scaler
+     *                    0: 64:1
+     *                    1: 16:1
+     *                    2: 4:1
+     *                    3: 1:1
+     *             S-PRE: Secondary pre-scaler
+     *                    0: 8:1
+     *                    1: 7:1
+     *                    2: 6:1
+     *                    3: 5:1
+     *                    4: 4:1
+     *                    5: 3:1
+     *                    6: 2:1
+     *                    7: 1:1
+     *
+     * It returns nothing over serial.
+     * It sends an acknowledge byte (SUCCESS).
+     *
+     * @return SUCCESS
+     */
+    response_t SPI1_SetParameters(void);
+    
+    /**
+     * @brief Encapsulates read and write byte sized operations used in SPI 
+     * transactions. When reading back results, make sure to read one less byte
+     * as the first byte is assigned as register address. 
+     * 
+     * @param op Type of SPI operation mode (SPI1_OPERATION)
+     * @param count Number of UART interactions
+     * @param address Starting address of SPI register
+     * 
+     * @return None
+     */
+    void SPI1_ByteOperations(SPI1_OPERATION op, uint16_t count, uint8_t address);
+
+    /**
+     * @brief Writes a byte to a register address
+     *
+     * @description
+     * This method writes a single byte into a single SPI register address.
+     * This command takes two arguments over serial.
+     * 1. (uint8) Register address
+     * 2. (uint8) Data byte
+     *
+     * This will not return any result.
+     * 
+     * It sends an acknowledge byte (SUCCESS).
+     *
+     * @return SUCCESS
+     */
+    response_t SPI1_Write8(void);
+    
+    /**
+     * @brief Writes a stream of bytes to consecutive register locations
+     *
+     * @description
+     * This method writes a byte stream to a set of consecutive register 
+     * locations starting from a specific SPI address. 
+     * This method can also be used to write to multiple registers that are not
+     * located next to each other. In this case, user will create a stream of
+     * pair of bytes with the first element being the register address and the
+     * second element being the data to be written.
+     * This command takes three sets of arguments over serial.
+     * 1. (uint16) Byte count:
+     *             This count should include the total number of data bytes plus
+     *             one additional byte for the starting register address
+     * 2. (uint8) Starting register address
+     * 3. (uint8) Data bytes:
+     *            The number of data byte count should be one less than the byte
+     *            count in 1.
+     *
+     * This will not return any result.
+     * 
+     * It sends an acknowledge byte (SUCCESS).
+     *
+     * @return SUCCESS
+     */
+    response_t SPI1_Write8Burst(void);
+    
+    /**
+     * @brief Writes and reads a stream of bytes to and from consecutive 
+     * register locations
+     *
+     * @description
+     * This method alternatively write and read from SPI data registers.
+     * writes a byte stream to a set of consecutive register 
+     * locations starting from a specific SPI address.
+     * This command takes three sets of arguments over serial.
+     * 1. (uint16) Byte count:
+     *             This count should include the total number of control bytes
+     *             plus one additional byte for the starting register address
+     * 2. (uint8) Starting register address
+     * 3. (uint8) Control bytes:
+     *            The number of control byte count should be one less than the
+     *            byte count in 1.
+     *
+     * This will return a series of bytes correspond to each control byte sent
+     * as input. User must read one byte less than the byte count set as the 
+     * first input in 1.
+     * 
+     * It sends an acknowledge byte (SUCCESS).
+     *
+     * @return SUCCESS
+     */
+    response_t SPI1_Send8Burst(void);
+
+    /**
+     * @brief Reads bytes from an address
+     *
+     * @description
+     * This method reads byte chunks from a SPI register address.
+     * One can use this method to read a single byte or a sequence
+     * of bytes by changing the `number of bytes to read` argument.
+     * This command takes two arguments over serial.
+     * 1. (uint8) Register address
+     * 2. (uint16) Number of bytes to read
+     *
+     * This will return multiple bytes equal to the set number of
+     * bytes to read argument over serial.
+     * It sends an acknowledge byte (SUCCESS).
+     *
+     * @return SUCCESS
+     */
+    response_t SPI1_Read8Burst(void);
+
+#ifdef __cplusplus  // Provide C++ Compatibility
+}
+#endif
+
+#endif // SPI1_H

--- a/src/commands.c
+++ b/src/commands.c
@@ -1,5 +1,6 @@
 #include "commands.h"
 #include "bus/i2c/i2c.h"
+#include "bus/spi/spi1.h"
 #include "helpers/buffer.h"
 #include "helpers/device.h"
 #include "helpers/interval.h"
@@ -115,20 +116,20 @@ command_func_t* const cmd_table[NUM_PRIMARY_CMDS + 1][NUM_SECONDARY_CMDS_MAX + 1
         Undefined,                 Undefined,                     Undefined,                      Undefined,
     },
     { // 3 SPI
-     // 0               1 START_SPI           2 SEND_SPI8        3 SEND_SPI16
-        Undefined,      Unimplemented,        Unimplemented,     Unimplemented,
-     // 4 STOP_SPI      5 SET_SPI_PARAMETERS  6 SEND_SPI8_BURST  7 SEND_SPI16_BURST
-        Unimplemented,  Unimplemented,        Removed,           Removed,
-     // 8               9                     10                 11
-        Undefined,      Undefined,            Undefined,         Undefined,
-     // 12              13                    14                 15
-        Undefined,      Undefined,            Undefined,         Undefined,
-     // 16              17                    18                 19
-        Undefined,      Undefined,            Undefined,         Undefined,
-     // 20              21                    22                 23
-        Undefined,      Undefined,            Undefined,         Undefined,
-     // 24              25                    26                 27
-        Undefined,      Undefined,            Undefined,         Undefined,
+     // 0                               1 START_SPI                     2 SEND_SPI8                     3 SEND_SPI16
+        Undefined,                      SPI1_Start,                     SPI1_Write8,                    Unimplemented,
+     // 4 STOP_SPI                      5 SET_SPI_PARAMETERS            6 SEND_SPI8_BURST               7 SEND_SPI16_BURST
+        SPI1_Stop,                      SPI1_SetParameters,             SPI1_Send8Burst,                Unimplemented,
+     // 8 WRITE_SPI8_BURST              9 WRITE_SPI16_BURST             10 READ_SPI8_BURST              11 READ_SPI16_BURST
+        SPI1_Write8Burst,               Unimplemented,                  SPI1_Read8Burst,                Unimplemented,
+     // 12                              13                              14                              15
+        Undefined,                      Undefined,                      Undefined,                      Undefined,
+     // 16                              17                              18                              19
+        Undefined,                      Undefined,                      Undefined,                      Undefined,
+     // 20                              21                              22                              23
+        Undefined,                      Undefined,                      Undefined,                      Undefined,
+     // 24                              25                              26                              27
+        Undefined,                      Undefined,                      Undefined,                      Undefined,
     },
     { // 4 I2C
      // 0                               1 I2C_START                     2 I2C_SEND                      3 I2C_STOP

--- a/src/commands.h
+++ b/src/commands.h
@@ -20,7 +20,7 @@ extern "C" {
 #define NUM_PRIMARY_CMDS 13
 #define NUM_FLASH_CMDS 4
 #define NUM_ADC_CMDS 23
-#define NUM_SPI_CMDS 7
+#define NUM_SPI_CMDS 11
 #define NUM_I2C_CMDS 16
 #define NUM_UART2_CMDS 8
 #define NUM_DAC_CMDS 3


### PR DESCRIPTION
Addressing partly #105 

This will enable the use of SPI expansion header with external sensors.

Tested 8-bit read/write/exchange operations against NRF24 radio module using [this](https://www.sparkfun.com/datasheets/Components/SMD/nRF24L01Pluss_Preliminary_Product_Specification_v1_0.pdf) datasheet. 16-bits methods are also in code at a [fork](https://github.com/CloudyPadmal/pslab-firmware/tree/spi-8-16-methods) until they are tested against a sensor using 16-bit transactions. Therefore this PR only address 8-bit functions.