### PR TITLE
SPI chip select multiplexer

### DIFF
--- a/src/bus/i2c/i2c.c
+++ b/src/bus/i2c/i2c.c
@@ -673,7 +673,7 @@ response_t I2C_CommandStart(void) {
 
     uint8_t address = UART1_Read();
     
-    I2C_InitializeIfNot(I2C_GetBaudRate(), DISABLE_INTERRUPTS);
+    I2C_InitializeIfNot(I2C_GetBaudRate(), I2C_DISABLE_INTERRUPTS);
     I2C_StartSignal();
     I2C_Transmit(address);
     if (I2C_ACKNOWLEDGE_STATUS_BIT && I2C2STATbits.BCL) {
@@ -740,7 +740,7 @@ response_t I2C_CommandReadEnd(void) {
 response_t I2C_CommandConfig(void) {
     
     uint16_t baud_rate = UART1_ReadInt();
-    I2C_InitializeIfNot(baud_rate, DISABLE_INTERRUPTS);
+    I2C_InitializeIfNot(baud_rate, I2C_DISABLE_INTERRUPTS);
 
     return SUCCESS;
 }
@@ -817,7 +817,7 @@ response_t I2C_CommandDisableSMBus(void) {
 
 response_t I2C_CommandInit(void) {
 
-    I2C_InitializeIfNot(I2C_GetBaudRate(), DISABLE_INTERRUPTS);
+    I2C_InitializeIfNot(I2C_GetBaudRate(), I2C_DISABLE_INTERRUPTS);
     return SUCCESS;
 }
 

--- a/src/bus/i2c/i2c.h
+++ b/src/bus/i2c/i2c.h
@@ -11,8 +11,8 @@
 #define SLAVE_I2C_GENERIC_RETRY_MAX           100
 #define SLAVE_I2C_GENERIC_DEVICE_TIMEOUT      50
 
-#define ENABLE_INTERRUPTS                     true
-#define DISABLE_INTERRUPTS                    false
+#define I2C_ENABLE_INTERRUPTS                     true
+#define I2C_DISABLE_INTERRUPTS                    false
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/bus/spi/CMakeLists.txt
+++ b/src/bus/spi/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(pslab-firmware.elf PRIVATE
   spi1.c
   spi_driver.c
   spi_master.c
+  mux.c
 )
 
 target_include_directories(pslab-firmware.elf

--- a/src/bus/spi/mux.c
+++ b/src/bus/spi/mux.c
@@ -1,0 +1,104 @@
+/* mux.c
+ *
+ * A multiplexer controls the chip select (CS) pins of the PSLab's built-in
+ * SPI devices. The multiplexer is in turn controlled by MCU pins RA10,
+ * RA7, and RB9. Settings these pins either high or low results in one of the
+ * mux's seven outputs being driven low.
+ *
+ * However, in earlier versions of the hardware, the mux was not present. In
+ * the V5, only RA7 and RA10 are used, with each controlling the CS of one of
+ * the oscilloscope PGAs directly. The V5.5 added the SD-card slot and an
+ * external CS pin available on the SPI header. These are directly controlled
+ * by RB9 and RC4. In the V6, the RC4 pin is unconnected.
+ *
+ * The following table summarizes the above information:
+ *
+ * Pin states       | Asserted chip select(s)
+ * RC4 RB9 RA7 RA10 | V6    V5.5               V5
+ * 0   0   0   0      CH1   CH1, CH2, HD, SD   CH1, CH2
+ * 0   0   0   1      CH2   CH2, HD, SD        CH2
+ * 0   0   1   0      PS    CH1, HD, SD        CH1
+ * 0   0   1   1      NC    HD, SD             NC
+ * 0   1   0   0      HD    CH1, CH2, HD       CH1, CH2
+ * 0   1   0   1      SD    CH2, HD            CH2
+ * 0   1   1   0      NC    CH1, HD            CH1
+ * 0   1   1   1      NC    HD                 NC
+ * 1   0   0   0      CH1   CH1, CH2, SD       CH1, CH2
+ * 1   0   0   1      CH2   CH2, SD            CH2
+ * 1   0   1   0      PS    CH1, SD            CH1
+ * 1   0   1   1      NC    SD                 NC
+ * 1   1   0   0      HD    CH1, CH2           CH1, CH2
+ * 1   1   0   1      SD    CH2                CH2
+ * 1   1   1   0      NC    CH1                CH1
+ * 1   1   1   1      NC    NC                 NC
+ *
+ * CH1: Oscilloscope channel 1 programmable gain amplifier
+ * CH2: Oscilloscope channel 2 programmable gain amplifier
+ * PS:  Programmable current- and voltage sources
+ * HD:  External header pin
+ * SD:  SD-card
+ * NC:  Not connected / All CS pins deasserted
+ *
+ * This file provides an abstraction layer to control these pins in a way that
+ * is convenient and backwards compatible with older versions of the PSLab
+ * harware.
+ *
+ * Note to future developers: The V5.5 hardware was produced in very limited
+ * numbers and was only distributed to developers. Backwards compatibility
+ * with the V5.5 can therefore be safely broken if necessary.
+ */
+
+#include <xc.h>
+#include <stdint.h>
+
+#include "../../commands.h"
+#include "mux.h"
+
+/* Private definitions */
+
+struct MuxInput
+{
+    uint16_t RA10; ///< Mux pin S0.
+    uint16_t RA7;  ///< Mux pin S1.
+    uint16_t RB9;  ///< Mux pin S2. Not used in V5.
+    uint16_t RC4;  ///< Only used in V5.5.
+};
+
+void ChipSelect(struct MuxInput pins)
+{
+    _LATA10 = pins.RA10;
+    _LATA7  = pins.RA7;
+    _LATB9  = pins.RB9;
+    _LATC4  = pins.RC4;
+}
+
+/* Public definitions */
+
+void MUX_ChipSelect(tMUX_CS cs)
+{
+    #ifdef V5_HW
+    switch cs {
+    case MUX_CH1:
+        cs = _V5_CH1;
+        break;
+    case MUX_CH2:
+        cs = _V5_CH2;
+        break;
+    case MUX_HD:
+        cs = _V5_HD;
+        break;
+    case MUX_SD:
+        cs = _V5_SD;
+        break;
+    default:
+        cs = MUX_DEASSERT;
+    }
+    #endif // V5_HW
+    struct MuxInput pins = {
+        .RA10 = cs & 1,
+        .RA7 = (cs >> 1) & 1,
+        .RB9 = (cs >> 2) & 1,
+        .RC4 = (cs >> 3) & 1,
+    };
+    ChipSelect(pins);
+}

--- a/src/bus/spi/mux.h
+++ b/src/bus/spi/mux.h
@@ -1,0 +1,28 @@
+#ifndef _MUX_H
+#define _MUX_H
+
+/// @brief SPI chip select multiplexer.
+typedef enum
+{
+    MUX_CH1      = 0b0000, ///< CH1 PGA
+    MUX_CH2      = 0b0001, ///< CH2 PGA
+    MUX_PS       = 0b0010, ///< Power source
+    MUX_HD       = 0b0100, ///< Header pin
+    MUX_SD       = 0b0101, ///< SD-card
+    MUX_DEASSERT = 0b1111, ///< Deassert all
+    #ifdef V5_HW
+    // Backwards compatibility
+    _V5_CH1      = 0b1110,
+    _V5_CH2      = 0b1101,
+    _V5_HD       = 0b0111,
+    _V5_SD       = 0b1011,
+    #endif // V5_HW
+} tMUX_CS;
+
+/**
+ * @brief Assert a chip select pin.
+ * @param cs A tMUX_CS specifying the CS to assert.
+ */
+void MUX_ChipSelect(tMUX_CS cs);
+
+#endif // _MUX_H

--- a/src/bus/spi/spi1.h
+++ b/src/bus/spi/spi1.h
@@ -6,11 +6,9 @@
 #include <xc.h>
 
 #include "../../commands.h"
+#include "mux.h"
 
 #define SPI_BUFFER_SIZE     1000
-
-#define SPI1_ChipSelect()   CS_SPI_SetLow()
-#define SPI1_ChipDeselect() CS_SPI_SetHigh()
 
 #ifdef __cplusplus
 extern "C" {
@@ -137,19 +135,19 @@ extern "C" {
      * @return SUCCESS
      */
     response_t SPI1_SetParameters(void);
-    
+
     /**
-     * @brief Encapsulates read and write byte sized operations used in SPI 
+     * @brief Encapsulates read and write byte sized operations used in SPI
      * transactions. When reading back results, make sure to read one less byte
-     * as the first byte is assigned as register address. 
-     * 
+     * as the first byte is assigned as register address.
+     *
      * @param op Type of SPI operation mode (SPI1_OPERATION)
      * @param count Number of UART interactions
      * @param address Starting address of SPI register
-     * 
+     *
      * @return None
      */
-    void SPI1_ByteOperations(SPI1_OPERATION op, uint16_t count, uint8_t address);
+    void SPI1_ByteOperations(tMUX_CS cs, SPI1_OPERATION op, uint16_t count, uint8_t address);
 
     /**
      * @brief Writes a byte to a register address
@@ -161,19 +159,19 @@ extern "C" {
      * 2. (uint8) Data byte
      *
      * This will not return any result.
-     * 
+     *
      * It sends an acknowledge byte (SUCCESS).
      *
      * @return SUCCESS
      */
     response_t SPI1_Write8(void);
-    
+
     /**
      * @brief Writes a stream of bytes to consecutive register locations
      *
      * @description
-     * This method writes a byte stream to a set of consecutive register 
-     * locations starting from a specific SPI address. 
+     * This method writes a byte stream to a set of consecutive register
+     * locations starting from a specific SPI address.
      * This method can also be used to write to multiple registers that are not
      * located next to each other. In this case, user will create a stream of
      * pair of bytes with the first element being the register address and the
@@ -188,20 +186,20 @@ extern "C" {
      *            count in 1.
      *
      * This will not return any result.
-     * 
+     *
      * It sends an acknowledge byte (SUCCESS).
      *
      * @return SUCCESS
      */
     response_t SPI1_Write8Burst(void);
-    
+
     /**
-     * @brief Writes and reads a stream of bytes to and from consecutive 
+     * @brief Writes and reads a stream of bytes to and from consecutive
      * register locations
      *
      * @description
      * This method alternatively write and read from SPI data registers.
-     * writes a byte stream to a set of consecutive register 
+     * writes a byte stream to a set of consecutive register
      * locations starting from a specific SPI address.
      * This command takes three sets of arguments over serial.
      * 1. (uint16) Byte count:
@@ -213,9 +211,9 @@ extern "C" {
      *            byte count in 1.
      *
      * This will return a series of bytes correspond to each control byte sent
-     * as input. User must read one byte less than the byte count set as the 
+     * as input. User must read one byte less than the byte count set as the
      * first input in 1.
-     * 
+     *
      * It sends an acknowledge byte (SUCCESS).
      *
      * @return SUCCESS

--- a/src/helpers/rtc.c
+++ b/src/helpers/rtc.c
@@ -21,7 +21,7 @@ response_t RTC_SetTime(void) {
     buffer[7] = UART1_Read();         // year
     buffer[8] = UART1_Read();         // control
 
-    I2C_InitializeIfNot(I2C_BAUD_RATE_100KHZ, ENABLE_INTERRUPTS);
+    I2C_InitializeIfNot(I2C_BAUD_RATE_100KHZ, I2C_ENABLE_INTERRUPTS);
 
     return I2C_BulkWrite(buffer, 9, DS1307_I2C_DEVICE_ADDRESS);
 }
@@ -32,7 +32,7 @@ response_t RTC_SetDigit(void) {
     buffer[0] = UART1_Read();  // register address
     buffer[1] = UART1_Read();  // data
 
-    I2C_InitializeIfNot(I2C_BAUD_RATE_100KHZ, ENABLE_INTERRUPTS);
+    I2C_InitializeIfNot(I2C_BAUD_RATE_100KHZ, I2C_ENABLE_INTERRUPTS);
 
     return I2C_BulkWrite(buffer, 2, DS1307_I2C_DEVICE_ADDRESS);
 }
@@ -41,7 +41,7 @@ response_t RTC_GetTime(void) {
 
     uint8_t buffer[7];
 
-    I2C_InitializeIfNot(I2C_BAUD_RATE_100KHZ, ENABLE_INTERRUPTS);
+    I2C_InitializeIfNot(I2C_BAUD_RATE_100KHZ, I2C_ENABLE_INTERRUPTS);
 
     if(I2C_BulkRead(DS1307_DATA_REG_SECONDS, DS1307_I2C_DEVICE_ADDRESS, buffer, 7) == SUCCESS) {
         uint8_t i;
@@ -57,7 +57,7 @@ response_t RTC_GetDigit(void) {
     uint8_t reg = UART1_Read();  // register address
     uint8_t *pR = &reg;
 
-    I2C_InitializeIfNot(I2C_BAUD_RATE_100KHZ, ENABLE_INTERRUPTS);
+    I2C_InitializeIfNot(I2C_BAUD_RATE_100KHZ, I2C_ENABLE_INTERRUPTS);
 
     if(I2C_BulkRead(pR, DS1307_I2C_DEVICE_ADDRESS, buffer, 1) == SUCCESS) {
         UART1_Write(buffer[0]);

--- a/src/instruments/powersource.c
+++ b/src/instruments/powersource.c
@@ -14,8 +14,8 @@ response_t POWER_SOURCE_SetPower(void) {
     buffer[1] = (power >> 8) & 0x9F;
     buffer[2] = power & 0xFF;
 
-    I2C_InitializeIfNot(I2C_BAUD_RATE_400KHZ, ENABLE_INTERRUPTS);
-    
+    I2C_InitializeIfNot(I2C_BAUD_RATE_400KHZ, I2C_ENABLE_INTERRUPTS);
+
     return I2C_BulkWrite(buffer, 3, MCP4728_I2C_DEVICE_ADDRESS);
 }
 
@@ -25,7 +25,7 @@ response_t POWER_SOURCE_SetDAC(void) {
     uint8_t channel = UART1_Read();
     uint8_t power = UART1_ReadInt();
 
-    I2C_InitializeIfNot(I2C_BAUD_RATE_400KHZ, DISABLE_INTERRUPTS);
+    I2C_InitializeIfNot(I2C_BAUD_RATE_400KHZ, I2C_DISABLE_INTERRUPTS);
 
     I2C_StartSignal();
     I2C_Transmit(address);


### PR DESCRIPTION
This PR adds support for the new SPI chip select multiplexer added in the V6 hardware. It is a prerequisite for enabling the programmable power source, which the V6 moves from the I2C bus to the SPI bus.