### PR TITLE
Add support for MCP4822

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -166,7 +166,7 @@ command_func_t* const cmd_table[NUM_PRIMARY_CMDS + 1][NUM_SECONDARY_CMDS_MAX + 1
     },
     { // 6 DAC
      // 0                               1 SET_DAC                       2 SET_CALIBRATED_DAC            3 SET_POWER
-        Undefined,                      POWER_SOURCE_SetDAC,            Removed,                        POWER_SOURCE_SetPower,
+        Undefined,                      Removed,                        Removed,                        POWER_SOURCE_SetPower,
      // 4                               5                               6                               7
         Undefined,                      Undefined,                      Undefined,                      Undefined,
      // 8                               9                               10                              11

--- a/src/instruments/powersource.h
+++ b/src/instruments/powersource.h
@@ -1,7 +1,7 @@
 #ifndef POWER_SOURCE_H
 #define	POWER_SOURCE_H
 
-#include <xc.h> 
+#include <xc.h>
 
 #define MCP4728_I2C_DEVICE_ADDRESS        0x60
 
@@ -10,51 +10,32 @@ extern "C" {
 #endif /* __cplusplus */
 
     /**
-     * @brief This method setup power source individual channels with user set
-     * values
-     * 
-     * @description
-     * This command takes two argument over serial
-     * 1. (uint8)  power channel
-     *    This could be one of the four DAC channels 
-     *      - PCS - 0 (0b00)
-     *      - PV3 - 1 (0b01)
-     *      - PV2 - 2 (0b10)
-     *      - PV1 - 3 (0b11)
-     * 2. (uint16) power level
-     *    This is an integer value between 0 and 4095 correspond to the voltage 
-     * ratio. The first bit determines if the source is internal (1) or external
-     * (0).
-     * 
-     * It returns nothing over serial.
-     * 
+     * @brief Set the voltage output of the power source's individual channels.
+     *
+     * @param channel uint8_t
+     *        One of the DAC channels:
+     *        PSLab V6:
+     *        0 (0b00) - PCS & PVS2
+     *        1 (0b01) - PVS1 & PVS3
+     *        PSLab V5:
+     *        0 (0b00) - PCS
+     *        1 (0b01) - PV3
+     *        2 (0b10) - PV2
+     *        3 (0b11) - PV3
+     * @param power uint16
+     *        Integer value between 0 and 4095, corresponding to the voltage
+     *        ratio.
+     *        In the PSLab V5, the MSb determines if the voltage reference is
+     *        internal (1) or external (0). With internal reference, the
+     *        output range is 0 - 4.096 V with a resolution of 1 mV / bit;
+     *        with external reference, the range is 0 - 3.3 V with a resolution
+     *        of 806 µV / bit.
+     *        In the PSLab V6, only internal reference is available.
+     *
      * @return SUCCESS, FAILED
      */
     response_t POWER_SOURCE_SetPower(void);
 
-    /**
-     * @brief This method uses the legacy implementation to setup power source
-     * 
-     * @description
-     * This command takes three argument over serial
-     * 1. (uint8) address
-     *    This is the I2C device address for MCP4728 module
-     * 2. (uint8)  channel
-     *    This could be one of the four DAC channels 
-     *      - PCS - 0 (0b00)
-     *      - PV3 - 1 (0b01)
-     *      - PV2 - 2 (0b10)
-     *      - PV1 - 3 (0b11)
-     * 2. (uint16) power level
-     *    This is an integer value between 0 and 4095 correspond to the voltage 
-     * ratio.
-     * 
-     * It returns nothing over serial.
-     * 
-     * @return SUCCESS
-     */
-    response_t POWER_SOURCE_SetDAC(void);
-    
 #ifdef	__cplusplus
 }
 #endif


### PR DESCRIPTION
This enables the programmable power source in the V6. Depends on #148.

Also removes legacy power source command function.

Once this is merged, PSLab v6 has feature parity with v5.

Untested.