### PR TITLE
Harmonize V5 and V6 power source implementations

### DIFF
--- a/src/instruments/powersource.c
+++ b/src/instruments/powersource.c
@@ -8,7 +8,7 @@
 #include "powersource.h"
 
 
-#ifndef HW_V5
+#ifndef V5_HW
 
 /*********/
 /* Types */
@@ -107,4 +107,4 @@ response_t POWER_SOURCE_SetPower(void) {
     return I2C_BulkWrite(buffer, 3, MCP4728_I2C_DEVICE_ADDRESS);
 }
 
-#endif // HW_V5
+#endif // V5_HW

--- a/src/instruments/powersource.c
+++ b/src/instruments/powersource.c
@@ -15,31 +15,26 @@
 /*********/
 
 /// @brief DAC selection bit.
-enum DAC
-{
+enum DAC {
     DAC_A,
     DAC_B
 };
 
 /// @brief Output gain selection bit.
-enum Gain
-{
-    X2,
-    X1
+enum Gain {
+    GAIN_X2,
+    GAIN_X1
 };
 
 /// @brief Output shutdown control bit.
-enum Output
-{
-    SHUTDOWN,
-    ACTIVE
+enum Output {
+    OUTPUT_OFF,
+    OUTPUT_ON
 };
 
 /// @brief MCP4822 write command, 4 configuration bits + 12 data bits.
-union MCP4822Command
-{
-    struct
-    {
+union MCP4822Command {
+    struct {
         uint16_t DATA : 12;
         enum Output SHDN : 1;
         enum Gain GA : 1;
@@ -53,15 +48,14 @@ union MCP4822Command
 /* Static functions */
 /********************/
 
-static bool initialize(void)
-{
+static bool initialize(void) {
     const SPI_Config conf = {{{
         .PPRE = SPI_SCLK125000 >> 3,
         .SPRE = SPI_SCLK125000 & 7,
         .MSTEN = 1,
-        .CKP = 0,
+        .CKP = SPI_IDLE_LOW,
         .SSEN = 0,
-        .CKE = 1,
+        .CKE = SPI_SHIFT_TRAILING,
         .SMP = 1,
         .MODE16 = 1,
         .DISSDO = 0,
@@ -74,37 +68,62 @@ static bool initialize(void)
 /* Command functions */
 /*********************/
 
-response_t POWER_SOURCE_SetPower(void)
-{
-    const enum DAC dac = (UART1_Read() + 1) % 2;
-    const uint16_t power = UART1_ReadInt() & 0xFFF;
+response_t POWER_SOURCE_SetPower(void) {
+    enum DAC const dac = (UART1_Read() + 1) % 2;
+    uint16_t const voltage = UART1_ReadInt() & 0xFFF;
     union MCP4822Command cmd = {{
-        .DATA = power,
-        .SHDN = ACTIVE,
-        .GA = X2,
+        .DATA = voltage,
+        .SHDN = OUTPUT_ON,
+        .GA = GAIN_X2,
         .AB = dac
     }};
 
-    if(initialize())
-    {
-        return SPI_exchange_int(SPI_PS, &cmd.reg) ? SUCCESS : FAILED;
+    if(initialize()) {
+        return (
+            SPI_exchange_int(SPI_PS, &cmd.reg) ? SUCCESS : FAILED
+        );
     }
+
     return FAILED;
 }
 
 #else
 
-response_t POWER_SOURCE_SetPower(void) {
+union MCP4728Command {
+    struct {
+        uint16_t : 1; // UDAC
+        uint16_t DAC : 2;
+        uint16_t CMD : 5;
 
+        uint16_t DATA_H : 4;
+        uint16_t GX : 1;
+        uint16_t PDSEL : 2;
+        uint16_t VREF : 1;
+
+        uint16_t DATA_L : 8;
+    };
     uint8_t buffer[3];
-    buffer[0] = 0x58 | ((UART1_Read() & 0x03) << 1); // Channel
-    uint16_t power = UART1_ReadInt();
-    buffer[1] = (power >> 8) & 0x9F;
-    buffer[2] = power & 0xFF;
+};
 
+response_t POWER_SOURCE_SetPower(void) {
+    uint8_t const dac = UART1_Read() & 0x03;
+    uint16_t const voltage = UART1_ReadInt() & 0xFFF;
+    union MCP4728Command cmd = {{
+        .CMD = 0b01011, // Single write
+        .DAC = dac,
+        .VREF = 1, // Internal
+        .PDSEL = 0, // Normal mode
+        .GX = 1, // Gain x2
+        .DATA_L = voltage & 0xFF,
+        .DATA_H = (voltage >> 8) & 0xF
+    }};
     I2C_InitializeIfNot(I2C_BAUD_RATE_400KHZ, I2C_ENABLE_INTERRUPTS);
 
-    return I2C_BulkWrite(buffer, 3, MCP4728_I2C_DEVICE_ADDRESS);
+    return I2C_BulkWrite(
+        cmd.buffer,
+        sizeof(cmd.buffer),
+        MCP4728_I2C_DEVICE_ADDRESS
+    );
 }
 
 #endif // V5_HW

--- a/src/instruments/powersource.h
+++ b/src/instruments/powersource.h
@@ -21,16 +21,11 @@ extern "C" {
      *        0 (0b00) - PCS
      *        1 (0b01) - PV3
      *        2 (0b10) - PV2
-     *        3 (0b11) - PV3
-     * @param power uint16
-     *        Integer value between 0 and 4095, corresponding to the voltage
-     *        ratio.
-     *        In the PSLab V5, the MSb determines if the voltage reference is
-     *        internal (1) or external (0). With internal reference, the
-     *        output range is 0 - 4.096 V with a resolution of 1 mV / bit;
-     *        with external reference, the range is 0 - 3.3 V with a resolution
-     *        of 806 µV / bit.
-     *        In the PSLab V6, only internal reference is available.
+     *        3 (0b11) - PV1
+     * @param voltage uint16
+     *        Integer value between 0 and 3300, corresponding to the channel's
+     *        output voltage with 0 corresponding to the lowest voltage and
+     *        3300 to the highest.
      *
      * @return SUCCESS, FAILED
      */


### PR DESCRIPTION
The V5 power source can use either internal voltage reference (2.048 V), or use VDD as an external reference (default). The V6 only has internal reference. This PR makes it so the V5 also uses its internal reference instead of VDD, so as to make the two behave the same.