### PR TITLE
Add debug messages over serial

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,4 +26,9 @@ else()
   message("Building for PSLab v6")
 endif(LEGACY_HARDWARE)
 
+if (ENABLE_DEBUG)
+  message("Debug messages enabled")
+  add_compile_definitions(PSLAB_DEBUG)
+endif(ENABLE_DEBUG)
+
 bin2hex(pslab-firmware.elf)

--- a/src/commands.c
+++ b/src/commands.c
@@ -3,6 +3,7 @@
 #include "bus/uart/uart.h"
 #include "bus/spi/spi.h"
 #include "helpers/buffer.h"
+#include "helpers/debug.h"
 #include "helpers/device.h"
 #include "helpers/interval.h"
 #include "helpers/light.h"
@@ -247,8 +248,8 @@ command_func_t* const cmd_table[NUM_PRIMARY_CMDS + 1][NUM_SECONDARY_CMDS_MAX + 1
     { // 11 COMMON
      // 0                               1 GET_CTMU_VOLTAGE              2 GET_CAPACITANCE               3 GET_FREQUENCY
         Undefined,                      MULTIMETER_GetCTMUVolts,        MULTIMETER_GetCapacitance,      Unimplemented,
-     // 4 GET_INDUCTANCE                5 GET_VERSION                   6 GET_FW_VERSION                7
-        Unimplemented,                  DEVICE_GetVersion,              DEVICE_get_fw_version,          Undefined,
+     // 4 GET_INDUCTANCE                5 GET_VERSION                   6 GET_FW_VERSION                7 DEBUG_IS_ENABLED
+        Unimplemented,                  DEVICE_GetVersion,              DEVICE_get_fw_version,          DEBUG_is_enabled,
      // 8 RETRIEVE_BUFFER               9 GET_HIGH_FREQUENCY            10 CLEAR_BUFFER                 11 SET_RGB1
         BUFFER_Retrieve,                Unimplemented,                  BUFFER_Clear,                   Removed,
      // 12 READ_PROGRAM_ADDRESS         13 WRITE_PROGRAM_ADDRESS        14 READ_DATA_ADDRESS            15 WRITE_DATA_ADDRESS

--- a/src/helpers/CMakeLists.txt
+++ b/src/helpers/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(pslab-firmware.elf PRIVATE
   buffer.c
+  debug.c
   delay.c
   device.c
   interval.c

--- a/src/helpers/debug.c
+++ b/src/helpers/debug.c
@@ -1,0 +1,16 @@
+#include <stdbool.h>
+
+#include "../bus/uart/uart.h"
+#include "../commands.h"
+#include "debug.h"
+
+response_t DEBUG_is_enabled(void) {
+    #ifdef PSLAB_DEBUG
+        bool const IS_DEBUG_ENABLED = true;
+    #else
+        bool const IS_DEBUG_ENABLED = false;
+    #endif // PSLAB_DEBUG
+
+    UART1_Write(IS_DEBUG_ENABLED);
+    return DO_NOT_BOTHER;
+}

--- a/src/helpers/debug.h
+++ b/src/helpers/debug.h
@@ -1,0 +1,33 @@
+#ifndef _DEBUG_H
+#define _DEBUG_H
+
+#include "../commands.h"
+
+// Enable debug messages over serial with -DENABLE_DEBUG CMake flag.
+
+#ifdef SERIAL_DEBUG
+    #define DEBUG_write_u8(byte) UART1_Write(byte)
+    #define DEBUG_write_u16(word) UART1_WriteInt(word)
+    #define DEBUG_write_u32(dword) UART1_write_u32(dword)
+#else
+    #define DEBUG_write_u8(byte) ((void)byte)
+    #define DEBUG_write_u16(word) ((void)word)
+    #define DEBUG_write_u32(dword) ((void)dword)
+#endif // SERIAL_DEBUG
+
+/**
+ * @brief Tell host whether debug messages are enabled.
+ *
+ * @details If the firmware was built with -DENABLE_DEBUG, extra messages
+ *     containing information that may be useful in debugging are sent over
+ *     serial, in addition to the messages which are normally sent. The host
+ *     must take this into consideration when communicating with the PSLab, so
+ *     that the correct number of bytes are read for each transaction.
+ *
+ * @return is_debug_enabled bool
+ *
+ * @return DO_NOT_BOTHER response_t
+ */
+response_t DEBUG_is_enabled(void);
+
+#endif // _DEBUG_H


### PR DESCRIPTION
Add `DEBUG_write_u8/u16/u32` functions, which send 1, 2, or 4 bytes over serial if firmware was built with `-DENABLE_DEBUG`. The functions do nothing otherwise.

Depends on #157.