### PR TITLE
Fix i2c bulk read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## [3.0.2] - 2024-07-28
+
+### Added
+
+- Add changelog (Alexander Bessman)
+
+### Fixed
+
+- Fix `I2C_CommandReadBulk` reading one too many bytes ([`4ea85ec`](https://github.com/fossasia/pslab-firmware/commit/4ea85ec9ecda2f9ec4dcab0b56f0de5edb6fbfaa)) (Alexander Bessman)
+
+## [3.0.1] - 2024-07-15
+
+### Fixed
+
+- Fix broken capacitance measurement ([`36d4fd3`](https://github.com/fossasia/pslab-firmware/commit/36d4fd31fe6edc3845e16ab71af899f61262b061)) (Alexander Bessman)
+- Fix second half of sample buffer not being cleared ([`54034b8`](https://github.com/fossasia/pslab-firmware/commit/54034b81549d735af3ab5050bdcd06a08269a6b2)) (Alexander Bessman)
+
+## [3.0.0] - 2024-01-15
+
+_Major refactorization of firmware._
+
+
+[3.0.0]: https://github.com/fossasia/pslab-firmware/releases/tag/v3.0.0

--- a/src/bus/i2c/i2c.c
+++ b/src/bus/i2c/i2c.c
@@ -768,7 +768,7 @@ response_t I2C_CommandReadBulk(void) {
     I2C_RestartSignal();
     I2C_Transmit((device << 1) | 1);
 
-    for (uint8_t i = 1; i < count; ++i) {
+    while (--count) {
         UART1_Write(I2C_Receive(I2C_RESPONSE_ACKNOWLEDGE));
     }
     UART1_Write(I2C_Receive(I2C_RESPONSE_NEGATIVE_ACKNOWLEDGE));


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes an off-by-one error in the I2C bulk read function and adds a check to handle zero-byte read requests. Additionally, the firmware version patch number has been incremented.

- **Bug Fixes**:
    - Fixed an off-by-one error in the I2C bulk read loop to correctly handle the number of bytes read.
- **Enhancements**:
    - Added a check to return immediately if the count of bytes to read is zero in the I2C bulk read function.
- **Chores**:
    - Updated the firmware version patch number from 1 to 2.

<!-- Generated by sourcery-ai[bot]: end summary -->