### PR TITLE
Fix UART2 pins not matching labels

### DIFF
--- a/src/registers/system/pin_manager.c
+++ b/src/registers/system/pin_manager.c
@@ -125,8 +125,8 @@ void PIN_MANAGER_Initialize(void) {
      ***************************************************************************/
     RPOR2bits.RP39R = RPN_U1TX_PORT; //RB7->UART1:U1TX
     RPINR18bits.U1RXR = RPI_RP40; //RB8->UART1:U1RX
-    RPOR2bits.RP38R = RPN_U2TX_PORT; // RB6->UART2:U2TX
-    RPINR19bits.U2RXR = RPI_RP37; // RB5->UART2:U2RX
+    RPOR1bits.RP37R = RPN_U2TX_PORT; // RB5->UART2:U2TX
+    RPINR19bits.U2RXR = RPI_RP38; // RB6->UART2:U2RX
 
     LED_SetHigh();
 }

--- a/src/registers/system/pin_manager.h
+++ b/src/registers/system/pin_manager.h
@@ -107,19 +107,19 @@
 #define UART1_TX_SetDigitalInput()     (_TRISB7 = 1)
 #define UART1_TX_SetDigitalOutput()    (_TRISB7 = 0)
 
-#define UART2_RX_SetHigh()             (_LATB5 = 1)
-#define UART2_RX_SetLow()              (_LATB5 = 0)
-#define UART2_RX_Toggle()              (_LATB5 ^= 1)
-#define UART2_RX_GetValue()            _RB5
-#define UART2_RX_SetDigitalInput()     (_TRISB5 = 1)
-#define UART2_RX_SetDigitalOutput()    (_TRISB5 = 0)
+#define UART2_RX_SetHigh()             (_LATB6 = 1)
+#define UART2_RX_SetLow()              (_LATB6 = 0)
+#define UART2_RX_Toggle()              (_LATB6 ^= 1)
+#define UART2_RX_GetValue()            _RB6
+#define UART2_RX_SetDigitalInput()     (_TRISB6 = 1)
+#define UART2_RX_SetDigitalOutput()    (_TRISB6 = 0)
 
-#define UART2_TX_SetHigh()             (_LATB6 = 1)
-#define UART2_TX_SetLow()              (_LATB6 = 0)
-#define UART2_TX_Toggle()              (_LATB6 ^= 1)
-#define UART2_TX_GetValue()            _RB6
-#define UART2_TX_SetDigitalInput()     (_TRISB6 = 1)
-#define UART2_TX_SetDigitalOutput()    (_TRISB6 = 0)
+#define UART2_TX_SetHigh()             (_LATB5 = 1)
+#define UART2_TX_SetLow()              (_LATB5 = 0)
+#define UART2_TX_Toggle()              (_LATB5 ^= 1)
+#define UART2_TX_GetValue()            _RB5
+#define UART2_TX_SetDigitalInput()     (_TRISB5 = 1)
+#define UART2_TX_SetDigitalOutput()    (_TRISB5 = 0)
 
 /*******************************************************************************
  * Oscilloscope


### PR DESCRIPTION
Fix #177

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix UART2 pin assignments to ensure they match the correct labels, addressing the mismatch issue in the pin manager configuration.

Bug Fixes:
- Correct UART2 pin assignments in the pin manager header and source files to match the correct labels, fixing the mismatch issue.

<!-- Generated by sourcery-ai[bot]: end summary -->