### PR TITLE
Release 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.0.4] - 2025-01-05
+
+### Fixed
+
+- Fix ACKSTAT missing from response in several I2C commands ([`6356eb2`](https://github.com/fossasia/pslab-firmware/commit/6356eb2656f856327c9090bcbd6e404db78ae2f0)) (Alexander Bessman)
+
 ## [3.0.3] - 2024-08-19
 
 ### Fixed
@@ -27,6 +33,7 @@
 
 _Major refactorization of firmware._
 
+[3.0.4]: https://github.com/fossasia/pslab-firmware/releases/tag/3.0.4
 [3.0.3]: https://github.com/fossasia/pslab-firmware/releases/tag/3.0.3
 [3.0.2]: https://github.com/fossasia/pslab-firmware/releases/tag/3.0.2
 [3.0.1]: https://github.com/fossasia/pslab-firmware/releases/tag/3.0.1

--- a/src/helpers/device.c
+++ b/src/helpers/device.c
@@ -24,7 +24,7 @@ static union {
 } const VERSION_FW = {{
     .major = 3,
     .minor = 0,
-    .patch = 3
+    .patch = 4
 }};
 
 response_t DEVICE_GetVersion(void) {


### PR DESCRIPTION
## Summary by Sourcery

Update firmware version to 3.0.4 and fix ACKSTAT missing from the response of some I2C commands.

Bug Fixes:
- Fix ACKSTAT missing from response in several I2C commands.

Chores:
- Bump version to 3.0.4.