### PR TITLE
fix: increased UART Read Timeout

### DIFF
--- a/src/bus/uart/uart.c
+++ b/src/bus/uart/uart.c
@@ -2,11 +2,12 @@
 #include "uart.h"
 #include "../../helpers/delay.h"
 #include "../../commands.h"
+#include "../../registers/system/watchdog.h"
 
 /**********/
 /* Macros */
 /**********/
-#define UART_READ_TIMEOUT (FCY / 1000)  // 1 ms
+#define UART_READ_TIMEOUT (FCY / 10UL)  // 100 ms
 
 /**************/
 /* Interrupts */
@@ -329,8 +330,9 @@ void UART_Initialize(const EUxSelect select) {
 
 uint8_t UART_Read(const EUxSelect select) {
     // Wait for data to become available.
-    uint16_t timeout = 0;
+    uint32_t timeout = 0;
     while (timeout++ < UART_READ_TIMEOUT) {
+        WATCHDOG_TimerClear();
         if (UART_IsRxReady(select)) {
             break;
         }


### PR DESCRIPTION
Increases the UART Read timeout to 100ms in our main firmware.
@bessman With the rolling out of [flutter 3.29](https://medium.com/flutter/whats-new-in-flutter-3-29-f90c380c2317), there have been quite some architectural changes, on how dart code is executed on Android and iOS.
One of them is execution of dart code on the main thread of the running application (which makes it a tiny bit slower, but slow enough to take slightly more than 1ms to transfer the command to the board, especially in _debug_ mode). 
In order to keep our app stable in flutter, we would most definitely require a timeout increase.

## Summary by Sourcery

Bug Fixes:
- Increased the UART read timeout to 100ms to improve stability with newer Flutter versions that execute Dart code on the main thread, potentially causing delays in command transfer, especially in debug mode. The watchdog timer is also cleared during the timeout period to prevent unexpected resets while waiting for data from the UART