### PR TITLE
chore: fix build

### DIFF
--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -46,7 +46,7 @@ jobs:
                 make
 
             - name: Publish build files
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                 name: production-file
                 path: build/*.hex


### PR DESCRIPTION
Bumps `actions/upload-artifact` from v3 to v4.
This is required to keep our _main-builder.yml_ running.
v3 has been deprecated and actions using that no longer run.

## Summary by Sourcery

CI:
- Update the "Publish build files" step in the _main-builder.yml_ workflow to use `actions/upload-artifact@v4` to fix a build issue caused by the deprecation of `actions/upload-artifact@v3`