### PR TITLE
Release/3.1.0

### DIFF
--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -5,48 +5,76 @@ on:
         branches: [ main ]
     pull_request:
         branches: [ main ]
+    workflow_call:
 
 jobs:
     build:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Download project files
-              uses: actions/checkout@v3
+      strategy:
+        matrix:
+          build_type: [v6, v5, v6_esp01]
+          include:
+            - build_type: v6
+              branch: main
+              cmake_flags: '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+            - build_type: v5
+              branch: main
+              cmake_flags: '-DCMAKE_BUILD_TYPE=RelWithDebInfo -DLEGACY_HARDWARE=1'
+            - build_type: v6_esp01
+              branch: esp-01
+              cmake_flags: '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
 
-            - name: Cache XC-16 Compiler
-              id: cache-compiler
-              uses: actions/cache@v3
-              with:
-                path: ~/.cache/mplab-xc
-                key: xc16-v2.10-cache
+      runs-on: ubuntu-latest
+      steps:
+          - name: Download project files
+            uses: actions/checkout@v4
+            with:
+              path: main
 
-            - name: Download XC16 Compiler
-              if: steps.cache-compiler.outputs.cache-hit != 'true'
-              run: |
-                mkdir -p ~/.cache/mplab-xc
-                cd ~/.cache/mplab-xc
-                wget https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/xc16-v2.10-full-install-linux64-installer.run
-                chmod +x xc16-v2.10-full-install-linux64-installer.run
+          - name: Checkout ESP01 branch
+            uses: actions/checkout@v4
+            with:
+              ref: esp-01
+              path: esp-01
 
-            - name: Install XC16 Compiler
-              run: |
-                cd ~/.cache/mplab-xc
-                sudo ./xc16-v2.10-full-install-linux64-installer.run --mode unattended --netservername dontknow
+          - name: Cache XC-16 Compiler
+            id: cache-compiler
+            uses: actions/cache@v3
+            with:
+              path: ~/.cache/mplab-xc
+              key: xc16-v2.10-cache
 
-            - name: Set up cmake-microchip submodules
-              run: |
-                git submodule init
-                git submodule update
+          - name: Download XC16 Compiler
+            if: steps.cache-compiler.outputs.cache-hit != 'true'
+            run: |
+              mkdir -p ~/.cache/mplab-xc
+              cd ~/.cache/mplab-xc
+              wget https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/xc16-v2.10-full-install-linux64-installer.run
+              chmod +x xc16-v2.10-full-install-linux64-installer.run
 
-            - name: Build firmware
-              run: |
-                mkdir build
-                cd build
-                cmake ..
-                make
+          - name: Install XC16 Compiler
+            run: |
+              cd ~/.cache/mplab-xc
+              sudo ./xc16-v2.10-full-install-linux64-installer.run --mode unattended --netservername dontknow
 
-            - name: Publish build files
-              uses: actions/upload-artifact@v4
-              with:
-                name: production-file
-                path: build/*.hex
+          - name: Set up cmake-microchip submodules
+            run: |
+              cd main
+              git submodule init
+              git submodule update
+              cd ../esp-01
+              git submodule init
+              git submodule update
+
+          - name: Build firmware
+            run: |
+              cd ${{ matrix.branch }}
+              mkdir build_${{ matrix.build_type }}
+              cd build_${{ matrix.build_type }}
+              cmake .. ${{ matrix.cmake_flags}}
+              make
+
+          - name: Publish build files
+            uses: actions/upload-artifact@v4
+            with:
+              name: pslab-firmware_${{ matrix.build_type}}
+              path: ${{ matrix.branch }}/build_${{ matrix.build_type }}/pslab-firmware.hex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  set-body:
+    runs-on: ubuntu-latest
+
+    steps:
+    - run: sudo apt install pcregrep
+
+    - uses: actions/checkout@v4
+
+    - name: Parse changelog
+      id: parse-changelog
+      run: |
+        tag='${{ github.ref_name }}'
+        re_current_tag="## \[$tag\].*\n\n" # Match, but do not capture, current version tag, then...
+        re_changes_body='((.|\n)+?)' # capture everything including newlines...
+        re_previous_tag='## \[[0-9]+.[0-9]+.[0-9]+\]' # until previous version tag.
+        re_full="${re_current_tag}${re_changes_body}${re_previous_tag}"
+        echo 'match<<EOF' >> $GITHUB_OUTPUT
+        # Match multiple lines, output capture group 1.
+        pcregrep -M -o1 "$re_full" ./CHANGELOG.md >> $GITHUB_OUTPUT
+        echo 'EOF' >> $GITHUB_OUTPUT
+
+    - name: Set release body
+      uses: softprops/action-gh-release@v2
+      with:
+        draft: true
+        body: ${{ steps.parse-changelog.outputs.match }}
+
+  build:
+    uses: fossasia/pslab-firmware/.github/workflows/main-builder.yml@main
+
+  attach-artifacts:
+    needs: build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: download
+        uses: actions/download-artifact@v4
+
+      - name: zip
+        run: |
+          zip -rj pslab-firmware_v6.zip pslab-firmware_v6/pslab-firmware.hex
+          zip -rj pslab-firmware_v5.zip pslab-firmware_v5/pslab-firmware.hex
+          zip -rj pslab-firmware_v6_esp01.zip pslab-firmware_v6_esp01/pslab-firmware.hex
+
+      - name: attach
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: pslab-firmware*
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [3.1.0] - 2025-02-17
+
+### Changed
+
+- Increase UART timeout ([`26de862`](https://github.com/fossasia/pslab-firmware/commit/26de86294997252c3c171e8be93c92410e57d354)) (Anashuman Singh)
+
+### Added
+
+- Document how to build for v5 hardware ([`1a5da5a`](https://github.com/fossasia/pslab-firmware/commit/1a5da5acb5eba67291d622cb9e4953167786c91d)) (Marc Nause)
+
 ## [3.0.4] - 2025-01-05
 
 ### Fixed
@@ -33,6 +43,7 @@
 
 _Major refactorization of firmware._
 
+[3.1.0]: https://github.com/fossasia/pslab-firmware/releases/tag/3.1.0
 [3.0.4]: https://github.com/fossasia/pslab-firmware/releases/tag/3.0.4
 [3.0.3]: https://github.com/fossasia/pslab-firmware/releases/tag/3.0.3
 [3.0.2]: https://github.com/fossasia/pslab-firmware/releases/tag/3.0.2

--- a/src/helpers/device.c
+++ b/src/helpers/device.c
@@ -23,8 +23,8 @@ static union {
     uint8_t const version[SEMVERS];
 } const VERSION_FW = {{
     .major = 3,
-    .minor = 0,
-    .patch = 4
+    .minor = 1,
+    .patch = 0
 }};
 
 response_t DEVICE_GetVersion(void) {


### PR DESCRIPTION
## Summary by Sourcery

Release version 3.1.0. Increase the UART timeout and document the build process for v5 hardware.

Enhancements:
- Increase UART timeout

Documentation:
- Document how to build for v5 hardware