### PR TITLE
feat: added Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    cmake \
+    make \
+    git \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN wget -qO- https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/xc16-v2.10-full-install-linux64-installer.run \
+    -O /tmp/xc16-installer.run && \
+    chmod +x /tmp/xc16-installer.run && \
+    /tmp/xc16-installer.run --mode unattended --prefix /opt/microchip/xc16/v2.10 --netservername "" && \
+    rm /tmp/xc16-installer.run


### PR DESCRIPTION
@bessman Doing this was so much easier than I thought !
Using a docker container to build the firmware is so convenient, practically eliminates all the hardships one has to go through while setting up the dev env.

**Image build logs**:
```bash
[+] Building 14.5s (8/8) FINISHED                                                                  docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 658B                                                                               0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                    2.5s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                      0.0s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 2B                                                                                    0.0s
 => [1/3] FROM docker.io/library/ubuntu:22.04@sha256:ed1544e454989078f5dec1bfdabd8c5cc9c48e0705d07b678ab6ae3fb619  0.0s
 => => resolve docker.io/library/ubuntu:22.04@sha256:ed1544e454989078f5dec1bfdabd8c5cc9c48e0705d07b678ab6ae3fb619  0.0s
 => CACHED [2/3] RUN apt-get update && apt-get install -y     cmake     make     git     wget     && rm -rf /var/  0.0s
 => CACHED [3/3] RUN wget -qO- https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/So  0.0s
 => exporting to image                                                                                            11.8s
 => => exporting layers                                                                                            0.0s
 => => exporting manifest sha256:9624d94b86c6d14ed0ef51d79693af3327ec342e367be67e28337faa289afada                  0.0s
 => => exporting config sha256:7834980e6e51e2546b83f7cf14e018c94adb726af854526a3ce27157b9fa68fd                    0.0s
 => => exporting attestation manifest sha256:a549d715d74933a8d3020ee7c5c07e2714411720931a44e76ea7384d16d73959      0.0s
 => => exporting manifest list sha256:98bc43ada9d66b1ac2eb6b0ddccdb86ac6b496f861c89c749d706eee4f14976f             0.0s
 => => naming to docker.io/library/pslab-firmware_image:latest                                                     0.0s
 => => unpacking to docker.io/library/pslab-firmware_image:latest                                                 11.7s

View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/mi59q2kmg0vrzyauq3ca8f3rj
```

**Firmware build process inside the container**:
```sh
# git clone https://github.com/fossasia/pslab-firmware.git
Cloning into 'pslab-firmware'...
remote: Enumerating objects: 2864, done.
remote: Counting objects: 100% (466/466), done.
remote: Compressing objects: 100% (154/154), done.
remote: Total 2864 (delta 362), reused 312 (delta 312), pack-reused 2398 (from 1)
Receiving objects: 100% (2864/2864), 45.18 MiB | 3.73 MiB/s, done.
Resolving deltas: 100% (1874/1874), done.
# cd pslab-firmware
# git submodule init
Submodule 'external/cmake-microchip' (https://github.com/fossasia/cmake-microchip) registered for path 'external/cmake-microchip'
# git submodule update
Cloning into '/pslab-firmware/external/cmake-microchip'...
Submodule path 'external/cmake-microchip': checked out '5711d67ad778c64c85a75e5d55a3b9a09a631fa6'
# mkdir build
# cd build
# cmake ..
-- Using Microchip C compiler XC16 2.10
-- The ASM compiler identification is GNU
-- Found assembler: /opt/microchip/xc16/v2.10/bin/xc16-gcc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /opt/microchip/xc16/v2.10/bin/xc16-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
Building for PSLab v6
-- Configuring done
-- Generating done
-- Build files have been written to: /pslab-firmware/build
# make
Scanning dependencies of target pslab-firmware.elf
[  1%] Building ASM object CMakeFiles/pslab-firmware.elf.dir/src/boot/hardware_interrupt_table.S.obj
[  3%] Building ASM object CMakeFiles/pslab-firmware.elf.dir/src/boot/interrupts.S.obj
[  5%] Building ASM object CMakeFiles/pslab-firmware.elf.dir/src/boot/memory_partition.S.obj
[  6%] Building ASM object CMakeFiles/pslab-firmware.elf.dir/src/boot/remapped_reset.S.obj
[  8%] Building ASM object CMakeFiles/pslab-firmware.elf.dir/src/boot/user_interrupt_table.S.obj
[ 10%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/bus/i2c/i2c.c.obj
[ 11%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/bus/spi/spi.c.obj
[ 13%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/bus/uart/uart.c.obj
[ 15%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/helpers/buffer.c.obj
[ 16%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/helpers/debug.c.obj
[ 18%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/helpers/delay.c.obj
[ 20%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/helpers/device.c.obj
[ 21%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/helpers/interval.c.obj
[ 23%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/helpers/light.c.obj
[ 25%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/helpers/rtc.c.obj
[ 26%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/instruments/logicanalyzer.c.obj
[ 28%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/instruments/multimeter.c.obj
[ 30%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/instruments/oscilloscope.c.obj
[ 31%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/instruments/powersource.c.obj
[ 33%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/instruments/sensors.c.obj
[ 35%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/instruments/wavegenerator.c.obj
[ 36%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/cmp_params.c.obj
[ 38%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/cmp1.c.obj
[ 40%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/cmp2.c.obj
[ 41%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/cmp3.c.obj
[ 43%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/cmp4.c.obj
[ 45%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/cvr.c.obj
[ 46%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/ic_params.c.obj
[ 48%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/ic1.c.obj
[ 50%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/ic2.c.obj
[ 51%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/ic3.c.obj
[ 53%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/ic4.c.obj
[ 55%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/oc1.c.obj
[ 56%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/oc2.c.obj
[ 58%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/oc3.c.obj
[ 60%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/comparators/oc4.c.obj
[ 61%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/converters/adc1.c.obj
[ 63%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/converters/ctmu.c.obj
[ 65%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/memory/dma.c.obj
[ 66%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/system/clock.c.obj
[ 68%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/system/interrupt_manager.c.obj
[ 70%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/system/pin_manager.c.obj
[ 71%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/system/system.c.obj
[ 73%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/timers/tmr1.c.obj
[ 75%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/timers/tmr2.c.obj
[ 76%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/timers/tmr3.c.obj
[ 78%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/timers/tmr4.c.obj
[ 80%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/registers/timers/tmr5.c.obj
[ 81%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/sdcard/fatfs/diskio.c.obj
/pslab-firmware/src/sdcard/fatfs/diskio.c: In function 'disk_ioctl':
/pslab-firmware/src/sdcard/fatfs/diskio.c:131:14: warning: unused parameter 'cmd'
/pslab-firmware/src/sdcard/fatfs/diskio.c:132:15: warning: unused parameter 'buff'
[ 83%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/sdcard/fatfs/fatfs_demo.c.obj
[ 85%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/sdcard/fatfs/ff_time.c.obj
[ 86%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/sdcard/fatfs/ff.c.obj
[ 88%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/sdcard/fatfs/ffsystem.c.obj
[ 90%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/sdcard/fatfs/ffunicode.c.obj
[ 91%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/sdcard/sd_spi.c.obj
[ 93%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/sdcard/sdcard.c.obj
[ 95%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/commands.c.obj
[ 96%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/main.c.obj
[ 98%] Building C object CMakeFiles/pslab-firmware.elf.dir/src/states.c.obj
[100%] Linking C executable pslab-firmware.elf

Info: Loading file: /opt/microchip/xc16/v2.10/bin/bin/../../support/PIC24E/gld/p24EP256GP204.gld


xc16-ld 2.10 (A)

Default Code Model: Small
Default Data Model: Large
Default Scalar Model: Small

"program" Memory  [Origin = 0x200, Length = 0x2adec]

section                    address   length (PC units)   length (bytes) (dec)
-------                    -------   -----------------   --------------------
/pslab-firmware/src/boot/memory_partition.S.scn1     0x200              0x1600          0x2100  (8448)
app_reset_section           0x1800                 0x4             0x6  (6)
.text                       0x1804               0x1ec           0x2e2  (738)
.text                       0x19f0                0x10            0x18  (24)
__remapped_DefaultInterrupt    0x1a00                 0x4             0x6  (6)
remappedOscillatorFail      0x1a04                 0x4             0x6  (6)
remappedAddressError        0x1a08                 0x4             0x6  (6)
remappedHardTrapError       0x1a0c                 0x4             0x6  (6)
remappedStackError          0x1a10                 0x4             0x6  (6)
remappedMathError           0x1a14                 0x4             0x6  (6)
remappedDMACError           0x1a18                 0x4             0x6  (6)
remappedSoftTrapError       0x1a1c                 0x4             0x6  (6)
remappedINT0Interrupt       0x1a20                 0x4             0x6  (6)
remappedIC1Interrupt        0x1a24                 0x4             0x6  (6)
remappedOC1Interrupt        0x1a28                 0x4             0x6  (6)
remappedT1Interrupt         0x1a2c                 0x4             0x6  (6)
remappedDMA0Interrupt       0x1a30                 0x4             0x6  (6)
remappedIC2Interrupt        0x1a34                 0x4             0x6  (6)
remappedOC2Interrupt        0x1a38                 0x4             0x6  (6)
remappedT2Interrupt         0x1a3c                 0x4             0x6  (6)
remappedT3Interrupt         0x1a40                 0x4             0x6  (6)
remappedSPI1ErrInterrupt    0x1a44                 0x4             0x6  (6)
remappedSPI1Interrupt       0x1a48                 0x4             0x6  (6)
remappedU1RXInterrupt       0x1a4c                 0x4             0x6  (6)
remappedU1TXInterrupt       0x1a50                 0x4             0x6  (6)
remappedAD1Interrupt        0x1a54                 0x4             0x6  (6)
remappedDMA1Interrupt       0x1a58                 0x4             0x6  (6)
remappedSI2C1Interrupt      0x1a5c                 0x4             0x6  (6)
remappedMI2C1Interrupt      0x1a60                 0x4             0x6  (6)
remappedCM1Interrupt        0x1a64                 0x4             0x6  (6)
remappedCNInterrupt         0x1a68                 0x4             0x6  (6)
remappedINT1Interrupt       0x1a6c                 0x4             0x6  (6)
remappedDMA2Interrupt       0x1a70                 0x4             0x6  (6)
remappedOC3Interrupt        0x1a74                 0x4             0x6  (6)
remappedOC4Interrupt        0x1a78                 0x4             0x6  (6)
remappedT4Interrupt         0x1a7c                 0x4             0x6  (6)
remappedT5Interrupt         0x1a80                 0x4             0x6  (6)
remappedINT2Interrupt       0x1a84                 0x4             0x6  (6)
remappedU2RXInterrupt       0x1a88                 0x4             0x6  (6)
remappedU2TXInterrupt       0x1a8c                 0x4             0x6  (6)
remappedSPI2ErrInterrupt    0x1a90                 0x4             0x6  (6)
remappedSPI2Interrupt       0x1a94                 0x4             0x6  (6)
remappedDMA3Interrupt       0x1a98                 0x4             0x6  (6)
remappedIC3Interrupt        0x1a9c                 0x4             0x6  (6)
remappedIC4Interrupt        0x1aa0                 0x4             0x6  (6)
remappedSI2C2Interrupt      0x1aa4                 0x4             0x6  (6)
remappedMI2C2Interrupt      0x1aa8                 0x4             0x6  (6)
remappedQEI1Interrupt       0x1aac                 0x4             0x6  (6)
remappedU1ErrInterrupt      0x1ab0                 0x4             0x6  (6)
remappedU2ErrInterrupt      0x1ab4                 0x4             0x6  (6)
remappedCRCInterrupt        0x1ab8                 0x4             0x6  (6)
remappedCTMUInterrupt       0x1abc                 0x4             0x6  (6)
remappedICDInterrupt        0x1ac0                 0x4             0x6  (6)
remappedJTAGInterrupt       0x1ac4                 0x4             0x6  (6)
remappedPTGSTEPInterrupt    0x1ac8                 0x4             0x6  (6)
remappedPTGWDTInterrupt     0x1acc                 0x4             0x6  (6)
remappedPTG0Interrupt       0x1ad0                 0x4             0x6  (6)
remappedPTG1Interrupt       0x1ad4                 0x4             0x6  (6)
remappedPTG2Interrupt       0x1ad8                 0x4             0x6  (6)
remappedPTG3Interrupt       0x1adc                 0x4             0x6  (6)
.text                       0x1ae0              0x10a8          0x18fc  (6396)
.const                      0x2b88               0x4dc           0x74a  (1866)
.text                       0x3064              0x4d60          0x7410  (29712)
.dinit                      0x7dc4               0x6cc           0xa32  (2610)
.text                       0x8490              0x26c4          0x3a26  (14886)
.text                       0xab54              0x1764          0x2316  (8982)
.init.delay32               0xc2b8                0x1c            0x2a  (42)
.text                       0xc2d4                0x18            0x24  (36)
.text                       0xc2ec                0x12            0x1b  (27)
/pslab-firmware/src/boot/memory_partition.S.scn2   0x2a800               0x7ea           0xbdf  (3039)

                 Total "program" memory used (bytes):        0x12d5c  (77148) 29%


"data" Memory  [Origin = 0x1000, Length = 0x8000]

section                    address      alignment gaps    total length  (dec)
-------                    -------      --------------    -------------------
.nbss                       0x1000                   0            0x3e  (62)
.ndata                      0x103e                   0             0xa  (10)
.nbss                       0x1048                   0             0x6  (6)
.ndata                      0x104e                   0             0x6  (6)
.nbss                       0x1054                   0             0x2  (2)
.ndata                      0x1056                   0             0x2  (2)
.nbss                       0x1058                   0             0xc  (12)
.adc_buffer                 0x1064                   0          0x4e20  (20000)
.bss                        0x5e84                   0           0x456  (1110)
.sine_table1                0x62da                   0           0x400  (1024)
.sine_table2                0x66da                   0           0x400  (1024)
.sine_table1_short          0x6ada                   0            0x40  (64)
.sine_table2_short          0x6b1a                   0            0x40  (64)
.data                       0x6b5a                   0            0x30  (48)
.bss                        0x6b8a                   0            0x30  (48)
.data                       0x6bba                   0            0x10  (16)
.bss                        0x6bca                   0             0xe  (14)
.data                       0x6bd8                   0            0x28  (40)
.bss                        0x6c00                   0             0x2  (2)

                 Total "data" memory used (bytes):         0x5c02  (23554) 71%


Dynamic Memory Usage

region                     address                      maximum length  (dec)
------                     -------                      ---------------------
heap                             0                                   0  (0)
stack                       0x6c02                              0x13fe  (5118)

                 Maximum dynamic memory (bytes):         0x13fe  (5118)

[100%] Built target pslab-firmware.elf
```

## Summary by Sourcery

Adds a Dockerfile to the project, enabling the use of a Docker container for building the firmware. This simplifies the development environment setup by encapsulating the necessary dependencies and build tools.

Build:
- Introduces a Dockerfile for building the firmware in a containerized environment.
- Installs necessary build tools like cmake, make, git, and wget within the Docker image.
- Downloads and installs the Microchip XC16 compiler.
- Sets environment variables for the XC16 compiler.