### PR TITLE
chore: include bootloader in release images

### DIFF
--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -31,7 +31,7 @@ jobs:
               ref: ${{ matrix.branch }}
               path: ${{ matrix.branch }}
 
-          - name: Cache XC-16 Compiler
+          - name: Cache Compilers
             id: cache-compiler
             uses: actions/cache@v3
             with:
@@ -64,9 +64,41 @@ jobs:
               cd build_${{ matrix.target }}
               cmake .. ${{ matrix.cmake_flags}}
               make
+          
+          - name: Build bootloader
+            run: |
+              git clone https://github.com/fossasia/pslab-bootloader.git pslab-bootloader
+              cd pslab-bootloader
+              git submodule init
+              git submodule update
+              mkdir build
+              cd build
+              cmake ..
+              make
 
+          - name: Download XC8 Compiler
+            if: steps.cache-compiler.outputs.cache-hit != 'true'
+            run: |
+              mkdir -p ~/.cache/mplab-xc
+              cd ~/.cache/mplab-xc
+              wget https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/xc8-v3.00-full-install-linux-x64-installer.run
+              chmod +x xc8-v3.00-full-install-linux-x64-installer.run
+
+          - name: Install XC8 Compiler
+            run: |
+              cd ~/.cache/mplab-xc
+              sudo ./xc8-v3.00-full-install-linux-x64-installer.run --mode unattended --netservername dontknow
+              echo "/opt/microchip/xc8/v3.00/pic/bin" >> $GITHUB_PATH
+
+          - name: Combining hex files
+            run: |
+              mv ${{ matrix.branch }}/build_${{ matrix.target }}/pslab-firmware.hex pslab-bootloader/build/pslab-firmware.hex
+              cd pslab-bootloader
+              chmod +x combine_hex.sh
+              ./combine_hex.sh  
+          
           - name: Publish build files
             uses: actions/upload-artifact@v4
             with:
               name: pslab-firmware_${{ matrix.target}}
-              path: ${{ matrix.branch }}/build_${{ matrix.target }}/pslab-firmware.hex
+              path: pslab-bootloader/build/combined.hex

--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -65,16 +65,13 @@ jobs:
               cmake .. ${{ matrix.cmake_flags}}
               make
           
-          - name: Build bootloader
+          - name: Fetch bootloader
             run: |
               git clone https://github.com/fossasia/pslab-bootloader.git pslab-bootloader
               cd pslab-bootloader
-              git submodule init
-              git submodule update
               mkdir build
               cd build
-              cmake ..
-              make
+              wget https://github.com/fossasia/pslab-bootloader/releases/latest/download/pslab-bootloader.hex
 
           - name: Download XC8 Compiler
             if: steps.cache-compiler.outputs.cache-hit != 'true'
@@ -90,7 +87,7 @@ jobs:
               sudo ./xc8-v3.00-full-install-linux-x64-installer.run --mode unattended --netservername dontknow
               echo "/opt/microchip/xc8/v3.00/pic/bin" >> $GITHUB_PATH
 
-          - name: Combining hex files
+          - name: Combine hex files
             run: |
               mv ${{ matrix.branch }}/build_${{ matrix.target }}/pslab-firmware.hex pslab-bootloader/build/pslab-firmware.hex
               cd pslab-bootloader


### PR DESCRIPTION
Fixes #189

As @bessman mentioned in the issue:
The current release process automatically builds and attaches firmware images to the release page. These firmware images include only the application firmware, not the bootloader. If someone were to flash these images with a PICkit, the existing bootloader would be erased and the PSLab would no longer be able to enter bootloader mode.

So, the bootloader image is added to the application image.

Did it in the following steps-

1. Building the bootloader image:
* Cloned the bootloader repository inside the container to access the files.
* Made a build folder similar to the firmware application image
* Used Cmake and make functions to make the .hex file from the .elf file.

2. Importing the XC8 compiler:
* Hexmate is used to combine the .hex files of the bootloader image and the application image into one file, which can be published and flashed to the _PSLab_ board.
* Now, Hexmate comes as a utility application as part of the XC8 compiler or the MPLABX IDE setup.
* Downloaded the XC8 compiler and picked hexmate from it.
* Before starting the download, cache the XC8 compiler similar to the XC16 compiler earlier in the build.
* Entered the cache directory and started the download.
* Now give permission to the .run file through chmod.

After the download, move to the installation.
* Here set the install settings to unattended so it can automatically install inside the container.
* Now, use the echo command to modify the system's PATH environment variable in GitHub's Actions workflow.

3. Combining the hexfile:
* The firmware.hex is present in the pslab-firmware/build directory, and the bootloader.hex is in the pslab-bootloader/build directory
* So, move the firmware.hex into the pslab-bootloader/build folder and then shift the container into the same folder.
* Give permission to combine.sh file in the pslab-bootloader directory and run it. It already has the definition to output combine.hex file

4. Publishing the build files:
* The final file, which is combined.hex is now present in the pslab-bootloader/build directory, so we pick it from there and publish it 

Successful action run:
https://github.com/Tejasgarg/pslab-firmware/actions/runs/14147713427/job/39637063463

## Summary by Sourcery

Modify the release build process to include the bootloader in the firmware image, ensuring a complete firmware package that can be flashed to the PSLab board without losing bootloader functionality.

New Features:
- Add bootloader to the firmware release image, enabling complete firmware flashing

CI:
- Update GitHub Actions workflow to build and combine bootloader and firmware hex files
- Add steps to download and install XC8 compiler for hex file manipulation

Chores:
- Modify release artifact publishing to include combined bootloader and firmware hex file