### PR TITLE
fix: increased UART timeout

### DIFF
--- a/src/bus/uart/uart.c
+++ b/src/bus/uart/uart.c
@@ -7,7 +7,7 @@
 /**********/
 /* Macros */
 /**********/
-#define UART_READ_TIMEOUT (FCY / 10UL)  // 100 ms
+#define UART_READ_TIMEOUT (FCY / 2UL)  // 500 ms
 
 /**************/
 /* Interrupts */


### PR DESCRIPTION
Increases UART Read Timeout in the ESP01 firmware to 500ms.

@bessman As I had expected, wireless communication in the _flutter_ app is a tiny bit slower as compared to the native app, but enough to cross the threshold of 200ms that we had set earlier if the _Oscilloscope_ runs for a minute straight due to random latencies in communication. Therefore, I propose that we increase the timeout further to match with the client side (i.e., 500 ms). This has been tested by me and found to be working with the _flutter_ app; the communication desyncs are no more there (tested with the _Oscilloscope_ running for 15 minutes straight).

## Summary by Sourcery

Bug Fixes:
- Increase UART read timeout from 100ms to 500ms to match client-side latency and eliminate communication desyncs.