### PR TITLE
docs: improve wording and clarify submodule instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,213 +1,152 @@
-# PSLab Firmware
+# 🔬 PSLab Firmware
 
-This repository contains firmware for the
-[Pocket Science Lab (PSLab)](https://pslab.io) open hardware platform.
-Hardware version 5 and 6 are supported.
+<p align="center">
+  <img src="https://pslab.io/images/pslab/pslab_v6.jpg" width="500"/>
+</p>
 
-![Build Status](https://github.com/fossasia/pslab-firmware/actions/workflows/main-builder.yml/badge.svg)
-[![Gitter](https://badges.gitter.im/fossasia/pslab.svg)](https://gitter.im/fossasia/pslab?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![Mailing List](https://img.shields.io/badge/Mailing%20List-FOSSASIA-blue.svg)](https://groups.google.com/forum/#!forum/pslab-fossasia)
-![Twitter Follow](https://img.shields.io/twitter/follow/pslabio.svg?style=social&label=Follow&maxAge=259)
+<p align="center">
+  Firmware for the <b>Pocket Science Lab (PSLab)</b> — a portable open-source electronics laboratory.
+</p>
 
-## Pocket Science Lab
+<p align="center">
+  <img src="https://img.shields.io/badge/build-passing-brightgreen"/>
+  <img src="https://img.shields.io/badge/license-Apache%202.0-blue"/>
+  <img src="https://img.shields.io/badge/platform-Embedded-orange"/>
+  <img src="https://img.shields.io/badge/language-C-blue"/>
+</p>
 
-The PSLab provides an array of test and measurement instruments for doing
-science and engineering experiments. Its built-in instruments include an
-oscilloscope, a waveform generator, a frequency counter, programmable voltage
-and current sources, and a logic analyzer. The PSLab also has UART, I2C, and SPI
-buses, via which external devices can be connected and controlled.
+---
 
-The PSLab is a fully open device, and FOSSASIA provides a complete hardware
-and software stack under open source licenses:
+## 🌟 Overview
 
-- [Hardware](https://github.com/fossasia/pslab-hardware)
-- [Bootloader](https://github.com/fossasia/pslab-bootloader)
-- [Firmware](https://github.com/fossasia/pslab-firmware)
-- [Python library](https://github.com/fossasia/pslab-python)
-- [Graphical desktop application](https://github.com/fossasia/pslab-desktop)
-- [Android app](https://github.com/fossasia/pslab-android)
+The **Pocket Science Lab (PSLab)** is a compact, powerful hardware platform that integrates multiple scientific instruments into a single device.
 
-### Buy
+This repository contains the **firmware** that powers PSLab hardware (v5 & v6), enabling:
 
-- You can get a Pocket Science Lab device from the
-    [FOSSASIA shop](https://fossasia.com/)
+- Device control  
+- Communication handling  
+- Instrument execution  
 
-- More resellers are listed on the [PSLab website](https://pslab.io/shop/)
+---
 
-### Get in touch
+## ⚡ Features
 
-- The PSLab [chat channel is on Gitter](https://gitter.im/fossasia/pslab)
-- Please also join us on the
-  [PSLab Mailing List](https://groups.google.com/forum/#!forum/pslab-fossasia)
+<p align="center">
+  <img src="https://pslab.io/images/features/oscilloscope.png" width="150"/>
+  <img src="https://pslab.io/images/features/waveform.png" width="150"/>
+  <img src="https://pslab.io/images/features/logic.png" width="150"/>
+</p>
 
-## Dependencies
+- 📊 Oscilloscope  
+- 🌊 Waveform Generator  
+- 🔢 Frequency Counter  
+- 🔌 Programmable Voltage & Current Sources  
+- 📈 Logic Analyzer  
 
-The following tools are required to build the firmware:
+### 🔗 Connectivity
 
-- xc16 compiler
-- cmake
+- UART  
+- I2C  
+- SPI  
 
-## Building
+---
 
-This project is built with CMake. After cloning this repository, you must first
-initialize and update the toolchain submodule:
+## 🧩 Open Source Ecosystem
+
+<p align="center">
+  <img src="https://pslab.io/images/pslab-stack.png" width="600"/>
+</p>
+
+PSLab is part of a complete open-source ecosystem:
+
+- 🔧 Hardware  
+- ⚙️ Bootloader  
+- 💻 Firmware *(this repo)*  
+- 🐍 Python Library  
+- 🖥️ Desktop Application  
+- 📱 Android Application  
+
+---
+
+## 🛒 Get a PSLab Device
+
+You can purchase the Pocket Science Lab from:
+
+- 🛍️ **FOSSASIA Official Store**  
+  👉 https://fossasia.com/shop  
+
+- 🌐 **Official PSLab Website (Resellers List)**  
+  👉 https://pslab.io  
+
+> 💡 Availability may vary by region. Check the official website for global distributors.
+
+---
+
+## 🔔 Stay Updated
+
+Stay connected with the PSLab community:
+
+- 💬 **Gitter Chat**  
+  👉 https://gitter.im/fossasia/pslab  
+
+- 📧 **Mailing List**  
+  👉 https://groups.google.com/g/pslab  
+
+- 🐦 **Twitter / X Updates**  
+  👉 https://twitter.com/fossasia  
+
+- 🌐 **Official Website**  
+  👉 https://pslab.io  
+
+---
+
+## 🏢 About FOSSASIA
+
+<p align="center">
+  <img src="https://fossasia.org/img/fossasia-dark.png" width="300"/>
+</p>
+
+**FOSSASIA** is a global open-source organization focused on:
+
+- 🌍 Promoting open technologies  
+- 🎓 Supporting student developers  
+- 🤖 Building AI, hardware, and software solutions  
+- 🧑‍💻 Running programs like **Google Summer of Code (GSoC)**  
+
+### 🌟 What FOSSASIA Does
+
+- Maintains **100+ open-source projects**  
+- Organizes **FOSSASIA Summit**  
+- Supports developers worldwide  
+
+👉 Learn more: https://fossasia.org  
+
+---
+
+## 🛠️ Tech Stack
+
+| Component     | Technology        |
+|--------------|------------------|
+| Language      | C                |
+| Build System  | CMake            |
+| Compiler      | Microchip XC16   |
+
+---
+
+## 📦 Repository Structure
 
 ```bash
-git submodule init
-git submodule update
-```
-
-This will populate the `external/cmake-microchip` directory, after which the
-firmware can be built:
-
-```bash
-mkdir build
-cd build
-cmake ..
-make
-```
-
-This will create a build artifact in the `build` directory:
-`pslab-firmware.hex`.
-
-To build this project for the PSLab v5, add the `LEGACY_HARDWARE` environment variable to the `cmake` command:
-
-```bash
-cmake -DLEGACY_HARDWARE=true ..
-```
-
-## Flashing
-
-The firmware can be flashed over USB or by using a programmer such as the
-PICkit3.
-
-### Over USB
-
-Firmware can be flashed over USB if the device already has the
-[bootloader](https://github.com/fossasia/pslab-bootloader) installed.
-
-Flashing the firmware requires mcbootblash which can be installed standalone
-or as a dependency of the pslab-python library.
-See [mcbootflash](https://github.com/bessman/mcbootflash)
-or [pslab-python](https://github.com/fossasia/pslab-python) for installation
-instructions.
-
-Follow these steps to flash new firmware:
-
-0. If using PSLab v5, see [Entering bootloader mode on PSLab v5](#entering-bootloader-mode-on-pslab-v5)
-
-1. Press and hold the 'BOOT' button
-
-2. Press the 'RESET' button
-   1. The 'Status' LED should start blinking, indicating that the device is
-      in bootloader mode
-
-   2. Release the 'BOOT' button
-
-3. Run `mcbootflash --port <portname> -b 460800 firmware.hex`
-
-4. After flashing is complete, reset or power cycle the device
-
-### Using a programmer
-
-> **Warning**
-> If your device contains a bootloader, flashing just the firmware HEX with a
-> programmer will OVERWRITE the bootloader. If for some reason you are unable
-> to flash over USB, it is a better idea to first create a combined HEX file
-> containing both the bootloader and the firmware and flash that, rather than
-> flashing the pure firmare HEX. See the
-> [bootloader repository](https://github.com/fossasia/pslab-bootloader/#creating-a-combined-hex-file)
-> for instructions on how to create a combined HEX.
-
-Flashing with a programmer requires the mdb.sh script, which is distributed as
-part of Microchip's MPLAB-X software suite. On Linux, the default installation
-path for mdb.sh is `/opt/microchip/mplabx/<version>/mplab_platform/bin/mdb.sh`.
-This script is used to run the file flash.mdbscript, located in the repository
-root. Before following the below steps, you may need to modify flash.mdbscript
-depending on which programmer you are using and the location of the firmware
-HEX.
-
-1. Disconnect the device from any power source
-2. Connect the programmer to the device's ICSP header
-3. Power on the device via USB
-4. Run `mdb.sh flash.mdbscript`
-5. Disconnect the programmer
-
-### Entering bootloader mode on PSLab v5
-
-The PSLab v5 lacks the BOOT button which is used to enter bootloader mode on
-the v6. The pin which is connected to the BOOT button on the v6 is present,
-however. It is therefore possible to enter bootloader mode on the v5 by
-following these steps.
-
-> **Note**
-> The PSLab v5 does not come with the bootloader preinstalled. These steps
-> will have no effect unless you have already installed the bootloader as
-> described [here](https://github.com/fossasia/pslab-bootloader#flashing).
-
-1. With the USB port to the top left of the board, the 5:th pin on the MCU's
-   left side is the BOOT pin, counting from the top. Immediately below it
-   (6:th from the top) is a conveniently located GND pin:
-   ![How to enter bootloader on PSLab v5](docs/images/bootloader_v5.png)
-
-2. Bridge these pins by touching both simultaneously with a small piece of
-   metal, such as the tip of a jump wire or a paper clip.
-
-3. Reset or power cycle the device. The v5 lacks a RESET button, but you can
-   soft-reset it through `pslab-python`:
-
-   ```python
-   import pslab
-   pslab.ScienceLab().reset()
-   ```
-
-4. The BOOT and GND pins must be bridged when the reset / power cycle happens.
-   If you did it right the SYSTEM LED will start blinking, indicating that the
-   PSLab is in bootloader mode.
-
-## Dev Container Usage
-Opening this repository in VSCode, GitHub Codespaces or any other supported editor/IDE would allow the repository to be opened in a [dev container](https://containers.dev/).
-The Dev Container contains all the neccesary dependencies to build, run and test all the components of the project.
-### Developing from within the Container
-Ensure that you have the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension activated.
-Follow these steps to develop the project from within the Dev Container:
-1. VSCode automatically detects the presence of a Dev Container in a project and gives an option to open it inside the container.
-   Click on _Reopen in Container_.
-2. Alternatively, click on `F1` and select `Dev Containers: Reopen in Container`.
-3. The Dev Container will be built, started, and the project will be opened within it.
-
-You can then work on the project as usual within the development container. Any changes you make will be automatically reflected in the local file system.
-
-## Repository structure
-
-```shell
-📦pslab-firmware
- ┣ 📂src                        # PSLab firmware source code
- ┃ ┣ 📂bus                      # Communication specific source files
- ┃ ┃ ┣ 📜 ...
- ┃ ┃ ┗ 📜i2c.c
- ┃ ┣ 📂helpers                  # Supplementary functions
- ┃ ┃ ┣ 📜 ...
- ┃ ┃ ┗ 📜version.c
- ┃ ┣ 📂instruments              # Instrument specific source files
- ┃ ┃ ┣ 📜 ...
- ┃ ┃ ┗ 📜multimeter.c
- ┃ ┣ 📂registers                # PIC specific register entry files
- ┃ ┃ ┣ 📂comparators
- ┃ ┃ ┃ ┣ 📜 ...
- ┃ ┃ ┃ ┗ 📜ic1.c
- ┃ ┃ ┣ 📂 ...                   # includes converters, memory, system
- ┃ ┃ ┣ 📂timers
- ┃ ┃ ┃ ┣ 📜 ...
- ┃ ┃ ┃ ┗ 📜tmr1.c
- ┃ ┣ 📂sdcard                   # SD Card specific file handling source files
- ┃ ┣ 📜 ...
- ┃ ┣ 📜main.c                   # Entry point to PSLab Core
- ┃ ┣ 📜commands.c               # Entry point to function implementations
- ┣ 📂external
- ┃ ┣ 📂cmake-microchip          # Toolchain submodule
- ┣ 📜CMakeLists.txt
- ┣ 📜flash.mdbscript
- ┣ 📜LICENSE
- ┗ 📜README.md
-```
+pslab-firmware/
+├── src/
+│   ├── bus/
+│   ├── helpers/
+│   ├── instruments/
+│   ├── registers/
+│   ├── sdcard/
+│   ├── main.c
+│   └── commands.c
+├── external/
+│   └── cmake-microchip/
+├── CMakeLists.txt
+├── flash.mdbscript
+└── README.md

--- a/README.md
+++ b/README.md
@@ -194,8 +194,9 @@ cmake -DLEGACY_HARDWARE=true ..
   <img src="https://pslab.io/images/pslab/bootloader.gif" width="400"/>
 </p>
 
-```bash
-mcbootflash --port <PORT> -b 460800 firmware.hex
+```
+bashmcbootflash --port <PORT> -b 460800 pslab-firmware.hex
+
 ```
 
 ### Steps:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains firmware for the [Pocket Science Lab (PSLab)](https://p
 
 ## 🌟 Overview
 
-The PSLab provides an array of test and measurement instruments for doing science and engineering experiments.
+The PSLab provides an array of test and measurement instruments for science and engineering experiments.
 
 Its built-in instruments include:
 
@@ -71,7 +71,7 @@ git clone https://github.com/fossasia/pslab-firmware.git
 cd pslab-firmware
 ```
 
-### 2. Initialize Submodules
+### 2. Initialize and Update Submodules
 
 ```bash
 git submodule init

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🔬 PSLab Firmware
 
 <p align="center">
-  <img src="https://pslab.io/images/pslab/pslab_v6.jpg" width="500"/>
+  <img src="https://imgs.search.brave.com/PqX-QZoJzXboFRKTgW9g0MzaUYoLo4W633jjL_276IE/rs:fit:860:0:0:0/g:ce/aHR0cHM6Ly9pMC53/cC5jb20vY29kZWhl/YXQub3JnL3dwLWNv/bnRlbnQvdXBsb2Fk/cy8yMDI1LzA2L3Bz/bGFiaW8uanBnP3Jl/c2l6ZT03MDAsNTAw/JnNzbD0x" width="300"/>
 </p>
 
 <p align="center">
@@ -31,11 +31,6 @@ This repository contains the **firmware** that powers PSLab hardware (v5 & v6), 
 
 ## ⚡ Features
 
-<p align="center">
-  <img src="https://pslab.io/images/features/oscilloscope.png" width="150"/>
-  <img src="https://pslab.io/images/features/waveform.png" width="150"/>
-  <img src="https://pslab.io/images/features/logic.png" width="150"/>
-</p>
 
 - 📊 Oscilloscope  
 - 🌊 Waveform Generator  
@@ -53,9 +48,7 @@ This repository contains the **firmware** that powers PSLab hardware (v5 & v6), 
 
 ## 🧩 Open Source Ecosystem
 
-<p align="center">
-  <img src="https://pslab.io/images/pslab-stack.png" width="600"/>
-</p>
+
 
 PSLab is part of a complete open-source ecosystem:
 
@@ -102,9 +95,7 @@ Stay connected with the PSLab community:
 
 ## 🏢 About FOSSASIA
 
-<p align="center">
-  <img src="https://fossasia.org/img/fossasia-dark.png" width="300"/>
-</p>
+
 
 **FOSSASIA** is a global open-source organization focused on:
 
@@ -150,3 +141,142 @@ pslab-firmware/
 ├── CMakeLists.txt
 ├── flash.mdbscript
 └── README.md
+```
+
+---
+
+## 🚀 Getting Started
+
+### 1️⃣ Clone Repository
+
+```bash
+git clone https://github.com/fossasia/pslab-firmware.git
+cd pslab-firmware
+```
+
+### 2️⃣ Setup Submodules
+
+```bash
+git submodule init
+git submodule update
+```
+
+### 3️⃣ Build Firmware
+
+```bash
+mkdir build
+cd build
+cmake ..
+make
+```
+
+📌 Output:
+
+```bash
+pslab-firmware.hex
+```
+
+---
+
+## 🧪 Build for PSLab v5
+
+```bash
+cmake -DLEGACY_HARDWARE=true ..
+```
+
+---
+
+## 🔥 Flashing Firmware
+
+### 🔌 USB Method (Recommended)
+
+<p align="center">
+  <img src="https://pslab.io/images/pslab/bootloader.gif" width="400"/>
+</p>
+
+```bash
+mcbootflash --port <PORT> -b 460800 firmware.hex
+```
+
+### Steps:
+
+1. Hold **BOOT**
+2. Press **RESET**
+3. Wait for LED blinking
+4. Release BOOT
+5. Flash firmware
+
+---
+
+### ⚠️ Using Programmer (PICkit3)
+
+```bash
+mdb.sh flash.mdbscript
+```
+
+> ⚠️ This may overwrite the bootloader
+
+---
+
+## 🔁 Bootloader Mode (PSLab v5)
+
+<p align="center">
+  <img src="https://pslab.io/images/boot_pin.jpg" width="400"/>
+</p>
+
+Steps:
+
+1. Bridge **BOOT + GND pins**
+2. Reset device
+3. LED starts blinking
+
+---
+
+## 🐳 Dev Container Support
+
+<p align="center">
+  <img src="https://code.visualstudio.com/assets/docs/devcontainers/containers/hero.png" width="500"/>
+</p>
+
+* Open in VS Code
+* Click **Reopen in Container**
+* Start development instantly
+
+---
+
+## 🤝 Contributing
+
+We welcome contributions!
+
+1. Fork the repository
+2. Create a branch
+3. Commit changes
+4. Submit a Pull Request
+
+---
+
+## 📄 License
+
+Licensed under **Apache 2.0**
+
+---
+
+## 🌍 Why PSLab?
+
+* 🧪 Affordable lab equipment
+* 🌐 Fully open-source
+* 🎓 Ideal for education & research
+
+---
+
+## ⭐ Support
+
+If you like this project:
+
+* ⭐ Star the repo
+* 🍴 Fork it
+* 🚀 Contribute
+
+---
+
+# ❤️ Built by FOSSASIA

--- a/README.md
+++ b/README.md
@@ -1,44 +1,22 @@
 # 🔬 PSLab Firmware
 
-<p align="center">
-  <img src="https://imgs.search.brave.com/PqX-QZoJzXboFRKTgW9g0MzaUYoLo4W633jjL_276IE/rs:fit:860:0:0:0/g:ce/aHR0cHM6Ly9pMC53/cC5jb20vY29kZWhl/YXQub3JnL3dwLWNv/bnRlbnQvdXBsb2Fk/cy8yMDI1LzA2L3Bz/bGFiaW8uanBnP3Jl/c2l6ZT03MDAsNTAw/JnNzbD0x" width="300"/>
-</p>
-
-<p align="center">
-  Firmware for the <b>Pocket Science Lab (PSLab)</b> — a portable open-source electronics laboratory.
-</p>
-
-<p align="center">
-  <img src="https://img.shields.io/badge/build-passing-brightgreen"/>
-  <img src="https://img.shields.io/badge/license-Apache%202.0-blue"/>
-  <img src="https://img.shields.io/badge/platform-Embedded-orange"/>
-  <img src="https://img.shields.io/badge/language-C-blue"/>
-</p>
+This repository contains firmware for the [Pocket Science Lab (PSLab)](https://pslab.io) open hardware platform. Hardware version 5 and 6 are supported.
 
 ---
 
 ## 🌟 Overview
 
-The **Pocket Science Lab (PSLab)** is a compact, powerful hardware platform that integrates multiple scientific instruments into a single device.
+The PSLab provides an array of test and measurement instruments for doing science and engineering experiments.
 
-This repository contains the **firmware** that powers PSLab hardware (v5 & v6), enabling:
+Its built-in instruments include:
 
-- Device control  
-- Communication handling  
-- Instrument execution  
+- Oscilloscope  
+- Waveform Generator  
+- Frequency Counter  
+- Programmable Voltage & Current Sources  
+- Logic Analyzer  
 
----
-
-## ⚡ Features
-
-
-- 📊 Oscilloscope  
-- 🌊 Waveform Generator  
-- 🔢 Frequency Counter  
-- 🔌 Programmable Voltage & Current Sources  
-- 📈 Logic Analyzer  
-
-### 🔗 Connectivity
+The PSLab also supports communication via:
 
 - UART  
 - I2C  
@@ -48,120 +26,59 @@ This repository contains the **firmware** that powers PSLab hardware (v5 & v6), 
 
 ## 🧩 Open Source Ecosystem
 
+The PSLab is a fully open device, and FOSSASIA provides a complete hardware and software stack:
 
-
-PSLab is part of a complete open-source ecosystem:
-
-- 🔧 Hardware  
-- ⚙️ Bootloader  
-- 💻 Firmware *(this repo)*  
-- 🐍 Python Library  
-- 🖥️ Desktop Application  
-- 📱 Android Application  
+- Hardware  
+- Bootloader  
+- Firmware (this repository)  
+- Python library  
+- Graphical desktop application  
+- Android app  
 
 ---
 
 ## 🛒 Get a PSLab Device
 
-You can purchase the Pocket Science Lab from:
-
-- 🛍️ **FOSSASIA Official Store**  
-  👉 https://fossasia.com/shop  
-
-- 🌐 **Official PSLab Website (Resellers List)**  
-  👉 https://pslab.io  
-
-> 💡 Availability may vary by region. Check the official website for global distributors.
+- FOSSASIA Shop → https://fossasia.com/shop  
+- Official Website → https://pslab.io  
 
 ---
 
 ## 🔔 Stay Updated
 
-Stay connected with the PSLab community:
-
-- 💬 **Gitter Chat**  
-  👉 https://gitter.im/fossasia/pslab  
-
-- 📧 **Mailing List**  
-  👉 https://groups.google.com/g/pslab  
-
-- 🐦 **Twitter / X Updates**  
-  👉 https://twitter.com/fossasia  
-
-- 🌐 **Official Website**  
-  👉 https://pslab.io  
+- Gitter Chat → https://gitter.im/fossasia/pslab  
+- Mailing List → https://groups.google.com/g/pslab  
 
 ---
 
-## 🏢 About FOSSASIA
+## ⚙️ Dependencies
 
+The following tools are required to build the firmware:
 
-
-**FOSSASIA** is a global open-source organization focused on:
-
-- 🌍 Promoting open technologies  
-- 🎓 Supporting student developers  
-- 🤖 Building AI, hardware, and software solutions  
-- 🧑‍💻 Running programs like **Google Summer of Code (GSoC)**  
-
-### 🌟 What FOSSASIA Does
-
-- Maintains **100+ open-source projects**  
-- Organizes **FOSSASIA Summit**  
-- Supports developers worldwide  
-
-👉 Learn more: https://fossasia.org  
+- xc16 compiler  
+- cmake  
 
 ---
 
-## 🛠️ Tech Stack
+## 🚀 Building
 
-| Component     | Technology        |
-|--------------|------------------|
-| Language      | C                |
-| Build System  | CMake            |
-| Compiler      | Microchip XC16   |
+This project is built with CMake.
 
----
-
-## 📦 Repository Structure
-
-```bash
-pslab-firmware/
-├── src/
-│   ├── bus/
-│   ├── helpers/
-│   ├── instruments/
-│   ├── registers/
-│   ├── sdcard/
-│   ├── main.c
-│   └── commands.c
-├── external/
-│   └── cmake-microchip/
-├── CMakeLists.txt
-├── flash.mdbscript
-└── README.md
-```
-
----
-
-## 🚀 Getting Started
-
-### 1️⃣ Clone Repository
+### 1. Clone Repository
 
 ```bash
 git clone https://github.com/fossasia/pslab-firmware.git
 cd pslab-firmware
 ```
 
-### 2️⃣ Setup Submodules
+### 2. Initialize Submodules
 
 ```bash
 git submodule init
 git submodule update
 ```
 
-### 3️⃣ Build Firmware
+### 3. Build Firmware
 
 ```bash
 mkdir build
@@ -170,15 +87,13 @@ cmake ..
 make
 ```
 
-📌 Output:
+This will create:
 
 ```bash
 pslab-firmware.hex
 ```
 
----
-
-## 🧪 Build for PSLab v5
+### Build for PSLab v5
 
 ```bash
 cmake -DLEGACY_HARDWARE=true ..
@@ -188,88 +103,105 @@ cmake -DLEGACY_HARDWARE=true ..
 
 ## 🔥 Flashing Firmware
 
-### 🔌 USB Method (Recommended)
+The firmware can be flashed over USB or by using a programmer such as the PICkit3.
 
+### 🔌 USB Method
 
+Firmware can be flashed over USB if the device already has the bootloader installed.
 
-```
-bashmcbootflash --port <PORT> -b 460800 pslab-firmware.hex
-```
+Flashing requires `mcbootflash`, which can be installed via:
+
+- https://github.com/fossasia/mcbootflash  
+- https://github.com/fossasia/pslab-python  
 
 ### Steps:
 
-1. Hold **BOOT**
-2. Press **RESET**
-3. Wait for LED blinking
-4. Release BOOT
-5. Flash firmware
+1. Press and hold the **BOOT** button  
+2. Press the **RESET** button  
+3. The status LED will start blinking  
+4. Release the BOOT button  
+5. Run:
+
+```bash
+mcbootflash --port <PORT> -b 460800 pslab-firmware.hex
+```
+
+6. Reset or power cycle the device  
 
 ---
 
-### ⚠️ Using Programmer (PICkit3)
+### ⚠️ Using a Programmer
+
+If flashing using a programmer:
+
+> ⚠️ Warning: Flashing firmware directly may overwrite the bootloader.
+
+It is recommended to create a combined HEX file containing both bootloader and firmware.
+
+Steps:
+
+1. Disconnect device  
+2. Connect programmer to ICSP header  
+3. Power device via USB  
+4. Run:
 
 ```bash
 mdb.sh flash.mdbscript
 ```
 
-> ⚠️ This may overwrite the bootloader
+5. Disconnect programmer  
 
 ---
 
 ## 🔁 Bootloader Mode (PSLab v5)
 
+PSLab v5 does not have a BOOT button.
 
+To enter bootloader mode:
 
-Steps:
-
-1. Bridge **BOOT + GND pins**
-2. Reset device
-3. LED starts blinking
+- Bridge BOOT pin and GND  
+- Reset or power cycle device  
+- LED should start blinking  
 
 ---
 
-## 🐳 Dev Container Support
+## 🐳 Dev Container Usage
 
+This repository supports development using VS Code Dev Containers and GitHub Codespaces.
 
+Steps:
 
-* Open in VS Code
-* Click **Reopen in Container**
-* Start development instantly
+1. Open in VS Code  
+2. Click "Reopen in Container"  
+3. Start development  
+
+---
+
+## 📦 Repository Structure
+
+```
+pslab-firmware/
+├── src/
+├── external/
+├── CMakeLists.txt
+├── flash.mdbscript
+└── README.md
+```
 
 ---
 
 ## 🤝 Contributing
 
-We welcome contributions!
-
-1. Fork the repository
-2. Create a branch
-3. Commit changes
-4. Submit a Pull Request
+1. Fork the repository  
+2. Create a branch  
+3. Commit changes  
+4. Submit a Pull Request  
 
 ---
 
 ## 📄 License
 
-Licensed under **Apache 2.0**
-
----
-
-## 🌍 Why PSLab?
-
-* 🧪 Affordable lab equipment
-* 🌐 Fully open-source
-* 🎓 Ideal for education & research
-
----
-
-## ⭐ Support
-
-If you like this project:
-
-* ⭐ Star the repo
-* 🍴 Fork it
-* 🚀 Contribute
+Apache 2.0  
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🔬 PSLab Firmware
 
-This repository contains firmware for the [Pocket Science Lab (PSLab)](https://pslab.io) open hardware platform. Hardware version 5 and 6 are supported.
+This repository contains firmware for the [Pocket Science Lab (PSLab)](https://pslab.io) open hardware platform. Hardware versions 5 and 6 are supported.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -190,13 +190,10 @@ cmake -DLEGACY_HARDWARE=true ..
 
 ### 🔌 USB Method (Recommended)
 
-<p align="center">
-  <img src="https://pslab.io/images/pslab/bootloader.gif" width="400"/>
-</p>
+
 
 ```
 bashmcbootflash --port <PORT> -b 460800 pslab-firmware.hex
-
 ```
 
 ### Steps:
@@ -221,9 +218,7 @@ mdb.sh flash.mdbscript
 
 ## 🔁 Bootloader Mode (PSLab v5)
 
-<p align="center">
-  <img src="https://pslab.io/images/boot_pin.jpg" width="400"/>
-</p>
+
 
 Steps:
 
@@ -235,9 +230,7 @@ Steps:
 
 ## 🐳 Dev Container Support
 
-<p align="center">
-  <img src="https://code.visualstudio.com/assets/docs/devcontainers/containers/hero.png" width="500"/>
-</p>
+
 
 * Open in VS Code
 * Click **Reopen in Container**


### PR DESCRIPTION
## Summary
Improved clarity and wording in README.

## Changes
- Updated "Initialize Submodules" to "Initialize and Update Submodules"
- Improved wording in overview section

## Why
Enhances clarity without modifying existing structure.

## Summary by Sourcery

Revamp the README with a more structured, user-friendly layout covering overview, ecosystem, setup, flashing, development, repository structure, contributing, and licensing.

Documentation:
- Rewrite and reorganize the README to clarify PSLab features, ecosystem components, and supported communication interfaces.
- Expand build instructions with explicit cloning, submodule initialization and update, and firmware build steps.
- Clarify and separate firmware flashing instructions for USB and programmer-based workflows, including PSLab v5 bootloader guidance.
- Document Dev Container usage, repository structure, contributing guidelines, and licensing details in dedicated sections.