### PR TITLE
fix: prevent UART FIFO overflow during I2C bulk write

### DIFF
--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -28,7 +28,7 @@ jobs:
           - name: Download project files
             uses: actions/checkout@v4
             with:
-              ref: ${{ matrix.branch }}
+              ref: ${{ github.head_ref || matrix.branch }}
               path: ${{ matrix.branch }}
 
           - name: Cache Compilers

--- a/.github/workflows/main-builder.yml
+++ b/.github/workflows/main-builder.yml
@@ -28,7 +28,6 @@ jobs:
           - name: Download project files
             uses: actions/checkout@v4
             with:
-              ref: ${{ github.head_ref || matrix.branch }}
               path: ${{ matrix.branch }}
 
           - name: Cache Compilers

--- a/src/bus/i2c/i2c.c
+++ b/src/bus/i2c/i2c.c
@@ -782,10 +782,10 @@ response_t I2C_CommandWriteBulk(void) {
     uint8_t device = UART1_Read();
     uint8_t count = UART1_Read();
 
-    static uint8_t usb_buffer[255]; 
+    static uint8_t payload[255]; 
     
     for (uint8_t i = 0; i < count; i++) {
-        usb_buffer[i] = UART1_Read();
+        payload[i] = UART1_Read();
         WATCHDOG_TimerClear(); 
     }
 
@@ -793,7 +793,7 @@ response_t I2C_CommandWriteBulk(void) {
     I2C_Transmit(device << 1);
 
     for (uint8_t i = 0; i < count; i++) {
-        I2C_Transmit(usb_buffer[i]);
+        I2C_Transmit(payload[i]);
         WATCHDOG_TimerClear(); 
     }
 

--- a/src/bus/i2c/i2c.c
+++ b/src/bus/i2c/i2c.c
@@ -2,7 +2,6 @@
 #include "../../bus/uart/uart.h"
 #include "../../helpers/delay.h"
 #include "../../registers/system/pin_manager.h"
-#include "../../registers/system/watchdog.h"
 /**
   I2C Driver Queue Status Type
 
@@ -786,7 +785,6 @@ response_t I2C_CommandWriteBulk(void) {
     
     for (uint8_t i = 0; i < count; i++) {
         payload[i] = UART1_Read();
-        WATCHDOG_TimerClear(); 
     }
 
     I2C_StartSignal();
@@ -794,7 +792,6 @@ response_t I2C_CommandWriteBulk(void) {
 
     for (uint8_t i = 0; i < count; i++) {
         I2C_Transmit(payload[i]);
-        WATCHDOG_TimerClear(); 
     }
 
     I2C_StopSignal();

--- a/src/bus/i2c/i2c.c
+++ b/src/bus/i2c/i2c.c
@@ -2,7 +2,7 @@
 #include "../../bus/uart/uart.h"
 #include "../../helpers/delay.h"
 #include "../../registers/system/pin_manager.h"
-
+#include "../../registers/system/watchdog.h"
 /**
   I2C Driver Queue Status Type
 
@@ -779,16 +779,22 @@ response_t I2C_CommandReadBulk(void) {
 }
 
 response_t I2C_CommandWriteBulk(void) {
-
     uint8_t device = UART1_Read();
     uint8_t count = UART1_Read();
+
+    static uint8_t usb_buffer[255]; 
+    
+    for (uint8_t i = 0; i < count; i++) {
+        usb_buffer[i] = UART1_Read();
+        WATCHDOG_TimerClear(); 
+    }
 
     I2C_StartSignal();
     I2C_Transmit(device << 1);
 
-    uint8_t i;
-    for (i = 0; i < count; i++) {
-        I2C_Transmit(UART1_Read());
+    for (uint8_t i = 0; i < count; i++) {
+        I2C_Transmit(usb_buffer[i]);
+        WATCHDOG_TimerClear(); 
     }
 
     I2C_StopSignal();

--- a/src/sdcard/sdcard.c
+++ b/src/sdcard/sdcard.c
@@ -16,12 +16,11 @@
 #define BUF_MAX FF_MIN_SS
 #define SDCARD_DRIVE "0:"
 
- #if FF_MIN_SS != 512
- #error "SD sector buffer must be 512 bytes"
- #endif
- 
 static TCHAR s_sector_buf[BUF_MAX];
-
+// _Static_assert(
+//     sizeof(s_sector_buf) == 512,
+//     "SD sector buffer must be 512 bytes"
+// );
 
 static void get_filename(TCHAR *const fn_buf, UINT const size)
 {

--- a/src/sdcard/sdcard.c
+++ b/src/sdcard/sdcard.c
@@ -16,11 +16,12 @@
 #define BUF_MAX FF_MIN_SS
 #define SDCARD_DRIVE "0:"
 
+ #if FF_MIN_SS != 512
+ #error "SD sector buffer must be 512 bytes"
+ #endif
+ 
 static TCHAR s_sector_buf[BUF_MAX];
-// _Static_assert(
-//     sizeof(s_sector_buf) == 512,
-//     "SD sector buffer must be 512 bytes"
-// );
+
 
 static void get_filename(TCHAR *const fn_buf, UINT const size)
 {

--- a/src/sdcard/sdcard.c
+++ b/src/sdcard/sdcard.c
@@ -16,11 +16,12 @@
 #define BUF_MAX FF_MIN_SS
 #define SDCARD_DRIVE "0:"
 
+ #if FF_MIN_SS != 512
+ #error "SD sector buffer must be 512 bytes"
+ #endif
+ 
 static TCHAR s_sector_buf[BUF_MAX];
-_Static_assert(
-    sizeof(s_sector_buf) == 512,
-    "SD sector buffer must be 512 bytes"
-);
+
 
 static void get_filename(TCHAR *const fn_buf, UINT const size)
 {


### PR DESCRIPTION
Fixes #206 

Large UART transfers could overflow the 4-byte UART FIFO because the host sends data faster than the I2C bus can transmit it, causing dropped bytes and client timeouts.

## Changes

- Added a 255-byte RAM buffer to `I2C_CommandWriteBulk`.
- Buffer the entire UART payload before starting the I2C transfer.
- Prevent UART FIFO overflows and dropped bytes during large transfers.

## Summary by Sourcery

Improve I2C bulk write handling by buffering incoming UART data and integrating watchdog servicing to ensure reliable large-transfer operation.

New Features:
- Buffer UART bulk-write payload in RAM before starting I2C transmission to support larger transfers without data loss.

Bug Fixes:
- Prevent UART FIFO overflow and dropped bytes during large I2C bulk writes by decoupling UART reception from I2C transmission.

Enhancements:
- Add watchdog timer clears during UART buffering and I2C transmission to avoid unintended resets during long bulk writes.