### PR TITLE
feat: state path to switch into standalone mode

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,11 +1,12 @@
 #include "registers/system/system.h"
 #include "states.h"
+#include "sdcard/sdcard.h"
 
 int main(void) {
     
     SYSTEM_Initialize();
 
-    state_t current_state = STATE_STANDBY;
+    state_t current_state = SDCARD_standalone_check() == SUCCESS ? STATE_STANDALONE : STATE_STANDBY;
 
     while (1) {
         current_state = STATES_RunState(current_state);

--- a/src/sdcard/sdcard.c
+++ b/src/sdcard/sdcard.c
@@ -163,26 +163,7 @@ static bool read_config_file(void) {
     }
     f_close(&file);
 
-    return true;
-}
-
-response_t SDCARD_standalone_check(void) {
-    if (!SD_SPI_IsMediaPresent()) {
-        return FAILED;
-    }
-
-    FATFS drive;
-    if (f_mount(&drive, SDCARD_DRIVE, 1) != FR_OK) {
-        return FAILED;
-    }
-    s_mounted = true;
-
-    if (!read_config_file()) {
-        SDCARD_standalone_unmount();
-        return FAILED;
-    }
-    
-    return SUCCESS;
+    return (buf[0] == 'P' && buf[1] == 'S' && buf[2] == 'L' && buf[3] == 'A' && buf[4] == 'B');
 }
 
 void SDCARD_standalone_unmount(void) {
@@ -190,4 +171,21 @@ void SDCARD_standalone_unmount(void) {
         f_mount(0, SDCARD_DRIVE, 0);
         s_mounted = false;
     }
+}
+
+response_t SDCARD_standalone_check(void) {
+    if (!SD_SPI_IsMediaPresent()) {
+        return FAILED;
+    }
+
+    static FATFS drive;
+    if (f_mount(&drive, SDCARD_DRIVE, 1) != FR_OK) {
+        s_mounted = false;
+        return FAILED;
+    }
+    s_mounted = true;
+
+    bool ok = read_config_file();
+    SDCARD_standalone_unmount();
+    return ok ? SUCCESS : FAILED;
 }

--- a/src/sdcard/sdcard.c
+++ b/src/sdcard/sdcard.c
@@ -15,7 +15,9 @@
 #define FILENAME_SIZE (SFN_MAX + SFN_SUFFIX_LEN + 1)
 #define BUF_MAX FF_MIN_SS
 #define SDCARD_DRIVE "0:"
+#define CONFIG_FILENAME "PSLAB.CFG"
 
+static bool s_mounted = false;
 static TCHAR s_sector_buf[BUF_MAX];
 _Static_assert(
     sizeof(s_sector_buf) == 512,
@@ -140,4 +142,52 @@ response_t SDCARD_get_file_info(void)
     DEBUG_write_u8(f_mount(0, SDCARD_DRIVE, 0));
 
     return SUCCESS;
+}
+
+/**
+ * @brief Read the configuration file from the SD card.
+ * @return true if the config file was read successfully, false otherwise or if the config structure is invalid.
+ */
+static bool read_config_file(void) {
+    FIL file;
+    if (f_open(&file, CONFIG_FILENAME, FA_READ) != FR_OK) {
+        return false;
+    }
+
+    TCHAR buf[6] = {0}; // Config file should have a magic header of 5 bytes
+    UINT bytes_read = 0;
+    if (f_read(&file, buf, sizeof buf - 1, &bytes_read) != FR_OK
+        || bytes_read != sizeof buf - 1) {
+        f_close(&file);
+        return false;
+    }
+    f_close(&file);
+
+    return true;
+}
+
+response_t SDCARD_standalone_check(void) {
+    if (!SD_SPI_IsMediaPresent()) {
+        return FAILED;
+    }
+
+    FATFS drive;
+    if (f_mount(&drive, SDCARD_DRIVE, 1) != FR_OK) {
+        return FAILED;
+    }
+    s_mounted = true;
+
+    if (!read_config_file()) {
+        SDCARD_standalone_unmount();
+        return FAILED;
+    }
+    
+    return SUCCESS;
+}
+
+void SDCARD_standalone_unmount(void) {
+    if (s_mounted) {
+        f_mount(0, SDCARD_DRIVE, 0);
+        s_mounted = false;
+    }
 }

--- a/src/sdcard/sdcard.h
+++ b/src/sdcard/sdcard.h
@@ -97,4 +97,15 @@ response_t SDCARD_read_file(void);
  */
 response_t SDCARD_get_file_info(void);
 
+/**
+ * @brief Check if SD-card is present and can be mounted.
+ * 
+ * @details Checks if the SD-card can be mounted and if the configuration file is present and valid.
+ *          If the configuration file is not present or invalid, or if the SD-card is not mounted, the function returns FAILED.
+ *          The configuration file is expected to be named "PSLAB.CFG" and contain a magic header of 5 bytes with a null terminator.
+ * 
+ * @return SUCCESS
+ */
+response_t SDCARD_standalone_check(void);
+
 #endif // _SDCARD_H

--- a/src/sdcard/sdcard.h
+++ b/src/sdcard/sdcard.h
@@ -98,6 +98,11 @@ response_t SDCARD_read_file(void);
 response_t SDCARD_get_file_info(void);
 
 /**
+ * @brief Unmount SD-card after standalone configuration checks.
+ */
+void SDCARD_standalone_unmount(void);
+
+/**
  * @brief Check if SD-card is present and can be mounted.
  * 
  * @details Checks if the SD-card can be mounted and if the configuration file is present and valid.

--- a/src/states.c
+++ b/src/states.c
@@ -43,8 +43,9 @@ state_t RunCommand(void) {
 state_t Standalone(void) {
     if (UART_IsRxReady(U1SELECT)) {
         return STATE_RUNCOMMAND;
-    }
-
+    } 
+    
+    WATCHDOG_TimerClear();
     return STATE_STANDALONE;
 }
 

--- a/src/states.c
+++ b/src/states.c
@@ -36,9 +36,22 @@ state_t RunCommand(void) {
     return STATE_STANDBY;
 }
 
+/**
+ * @brief Run in standalone mode until serial traffic is detected.
+ * @return STATE_STANDALONE or STATE_RUNCOMMAND if serial traffic is detected.
+ */
+state_t Standalone(void) {
+    if (UART_IsRxReady(U1SELECT)) {
+        return STATE_RUNCOMMAND;
+    }
+
+    return STATE_STANDALONE;
+}
+
 state_func_t* const state_table[NUM_STATES] = {
     Standby,
     RunCommand,
+    Standalone,
 };
 
 state_t STATES_RunState(state_t current_state) {

--- a/src/states.h
+++ b/src/states.h
@@ -16,6 +16,7 @@ extern "C" {
     typedef enum {
         STATE_STANDBY,
         STATE_RUNCOMMAND,
+        STATE_STANDALONE,
         NUM_STATES
     } state_t;
 


### PR DESCRIPTION
> [!IMPORTANT]  
> This is baby steps towards #46 and a purely experimental WIP pull request

When the PSLab boots, it will check for the presence of an SD card with a valid configuration file named `PSLAB.CFG`. If there is such a combination, PSLab will switch to a `standalone` mode; until serial traffic begins to appear.
If there is no such combination, then the device goes into stand by mode as usual.

Currently, the plan is to read from the SD card a set of bitmap images (or pre-conditioned image data) to display on an I2C OLED display as an animation. I expect the SD card to contain all the necessary parameters such as animation delay, duration, cycles etc to make the animation rendering possible.

## Summary by Sourcery

Introduce a standalone operational state that is activated on boot when a valid SD card configuration file is present, otherwise falling back to standby.

New Features:
- Add a standalone device state that runs until serial traffic is detected.
- Add SD card configuration detection via a PSLAB.CFG file with a simple header check to decide whether to enter standalone mode on boot.

Enhancements:
- Extend the global state table and main loop to support transitioning into and out of the new standalone state.
- Track SD card mount status and provide an explicit unmount function for standalone configuration checks.